### PR TITLE
Issue 70

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -43,53 +43,150 @@ import { GearModelComponent } from './views/architecture/gear-model/gear-model.c
 import { Title } from '@angular/platform-browser';
 
 const routes: Routes = [
-  { path: '', component: HomeComponent },
-  { path: 'search', component: GlobalSearchComponent },
-  { path: 'about', component: AboutComponent },
-  { path: 'about/:tab', component: AboutComponent },
-  { path: 'assist_tech', component: AssistTechComponent },
+  { path: '', component: HomeComponent, title: 'Home' },
+  { path: 'search', component: GlobalSearchComponent, title: 'Search' },
+  { path: 'about', component: AboutComponent, title: 'About' },
+  { path: 'about/:tab', component: AboutComponent, title: 'About' },
+  {
+    path: 'assist_tech',
+    component: AssistTechComponent,
+    title: 'Assistive Technology',
+  },
 
-  { path: 'strategic_framework', component: FrameworkComponent },
-  { path: 'investments', component: InvestmentsComponent },
-  { path: 'investments/:investID', component: InvestmentsComponent },
+  {
+    path: 'strategic_framework',
+    component: FrameworkComponent,
+    title: 'Strategic Framework',
+  },
+  {
+    path: 'investments',
+    component: InvestmentsComponent,
+    title: 'Investments',
+  },
+  {
+    path: 'investments/:investID',
+    component: InvestmentsComponent,
+    title: 'Investment',
+  },
 
-  { path: 'capabilities_model', component: CapabilitiesModelComponent },
-  { path: 'capabilities_model/:capID', component: CapabilitiesModelComponent },
-  { path: 'capabilities', component: CapabilitiesComponent },
-  { path: 'capabilities/:capID', component: CapabilitiesComponent },
-  { path: 'org_chart', component: OrganizationsChartComponent },
-  { path: 'org_chart/:orgID', component: OrganizationsChartComponent },
-  { path: 'organizations', component: OrganizationsComponent },
-  { path: 'organizations/:orgID', component: OrganizationsComponent },
-  { path: 'service_category', component: ServiceCategoryComponent },
+  {
+    path: 'capabilities_model',
+    component: CapabilitiesModelComponent,
+    title: 'Capabilities Model',
+  },
+  {
+    path: 'capabilities_model/:capID',
+    component: CapabilitiesModelComponent,
+    title: 'Capability Model',
+  },
+  {
+    path: 'capabilities',
+    component: CapabilitiesComponent,
+    title: 'Capabilities',
+  },
+  {
+    path: 'capabilities/:capID',
+    component: CapabilitiesComponent,
+    title: 'Capabilities',
+  },
+  {
+    path: 'org_chart',
+    component: OrganizationsChartComponent,
+    title: 'Org Chart',
+  },
+  {
+    path: 'org_chart/:orgID',
+    component: OrganizationsChartComponent,
+    title: 'Org Chart',
+  },
+  {
+    path: 'organizations',
+    component: OrganizationsComponent,
+    title: 'Organizations',
+  },
+  {
+    path: 'organizations/:orgID',
+    component: OrganizationsComponent,
+    title: 'Organization',
+  },
+  {
+    path: 'service_category',
+    component: ServiceCategoryComponent,
+    title: 'Service Categories',
+  },
   {
     path: 'service_category/:serviceCategoryID',
     component: ServiceCategoryComponent,
+    title: 'Service Category',
   },
 
-  { path: 'systems', component: SystemsComponent },
-  { path: 'systems/:sysID', component: SystemsComponent },
-  { path: 'systems_TIME', component: TimeComponent },
-  { path: 'systems_TIME/:sysID', component: TimeComponent },
-  { path: 'records_mgmt', component: RecordsManagementComponent },
-  { path: 'records_mgmt/:recID', component: RecordsManagementComponent },
-  { path: 'websites', component: WebsitesComponent, title: 'websites' },
-  { path: 'websites/:websiteID', component: WebsitesComponent },
+  { path: 'systems', component: SystemsComponent, title: 'Systems' },
+  { path: 'systems/:sysID', component: SystemsComponent, title: 'System' },
+  {
+    path: 'systems_TIME',
+    component: TimeComponent,
+    title: 'Systems TIME Model',
+  },
+  {
+    path: 'systems_TIME/:sysID',
+    component: TimeComponent,
+    title: 'System TIME Model',
+  },
+  {
+    path: 'records_mgmt',
+    component: RecordsManagementComponent,
+    title: 'Records Management',
+  },
+  {
+    path: 'records_mgmt/:recID',
+    component: RecordsManagementComponent,
+    title: 'Records Management',
+  },
+  { path: 'websites', component: WebsitesComponent, title: 'Websites' },
+  {
+    path: 'websites/:websiteID',
+    component: WebsitesComponent,
+    title: 'Website',
+  },
 
-  { path: 'FISMA', component: FismaComponent },
-  { path: 'FISMA/:fismaID', component: FismaComponent },
-  { path: 'FISMA_POC', component: FismaPocsComponent },
-  { path: 'FISMA_POC/:fismaID', component: FismaPocsComponent },
+  { path: 'FISMA', component: FismaComponent, title: 'FISMA Systems' },
+  { path: 'FISMA/:fismaID', component: FismaComponent, title: 'FISMA System' },
+  {
+    path: 'FISMA_POC',
+    component: FismaPocsComponent,
+    title: 'FISMA Point of Contacts',
+  },
+  {
+    path: 'FISMA_POC/:fismaID',
+    component: FismaPocsComponent,
+    title: 'FISMA Point of Contact',
+  },
 
-  { path: 'it_standards', component: ItStandardsComponent },
-  { path: 'it_standards/:standardID', component: ItStandardsComponent },
+  {
+    path: 'it_standards',
+    component: ItStandardsComponent,
+    title: 'IT Standards',
+  },
+  {
+    path: 'it_standards/:standardID',
+    component: ItStandardsComponent,
+    title: 'IT Standard',
+  },
 
-  { path: 'artifacts', component: ArtifactsComponent },
-  { path: 'gear_model', component: GearModelComponent },
+  { path: 'artifacts', component: ArtifactsComponent, title: 'Artifacts' },
+  { path: 'gear_model', component: GearModelComponent, title: 'GEAR Model' },
 
-  { path: 'forms_glossary', component: FormsGlossaryComponent },
+  {
+    path: 'forms_glossary',
+    component: FormsGlossaryComponent,
+    title: 'Forms Glossary',
+  },
 
-  { path: 'gear_manager', component: GearManagerComponent },
+  {
+    path: 'gear_manager',
+    component: GearManagerComponent,
+    title: 'GEAR Manager',
+  },
 
   {
     // Catch-all Redirect to Home

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,5 +1,10 @@
-import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import { Injectable, NgModule } from '@angular/core';
+import {
+  Routes,
+  RouterModule,
+  TitleStrategy,
+  RouterStateSnapshot,
+} from '@angular/router';
 
 // Main
 import { HomeComponent } from './views/main/home/home.component';
@@ -35,6 +40,7 @@ import { ItStandardsComponent } from './views/technologies/it-standards/it-stand
 // Enterprise Architecture
 import { ArtifactsComponent } from './views/architecture/artifacts/artifacts.component';
 import { GearModelComponent } from './views/architecture/gear-model/gear-model.component';
+import { Title } from '@angular/platform-browser';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -67,7 +73,7 @@ const routes: Routes = [
   { path: 'systems_TIME/:sysID', component: TimeComponent },
   { path: 'records_mgmt', component: RecordsManagementComponent },
   { path: 'records_mgmt/:recID', component: RecordsManagementComponent },
-  { path: 'websites', component: WebsitesComponent },
+  { path: 'websites', component: WebsitesComponent, title: 'websites' },
   { path: 'websites/:websiteID', component: WebsitesComponent },
 
   { path: 'FISMA', component: FismaComponent },
@@ -93,6 +99,20 @@ const routes: Routes = [
   },
 ];
 
+@Injectable({ providedIn: 'root' })
+export class TemplatePageTitleStrategy extends TitleStrategy {
+  constructor(private readonly title: Title) {
+    super();
+  }
+
+  override updateTitle(routerState: RouterStateSnapshot) {
+    const title = this.buildTitle(routerState);
+    if (title !== undefined) {
+      this.title.setTitle(`GEAR3 | ${title}`);
+    }
+  }
+}
+
 @NgModule({
   imports: [
     RouterModule.forRoot(routes, {
@@ -101,5 +121,6 @@ const routes: Routes = [
     }),
   ],
   exports: [RouterModule],
+  providers: [{ provide: TitleStrategy, useClass: TemplatePageTitleStrategy }],
 })
 export class AppRoutingModule {}

--- a/src/app/components/modals/capabilities-modal/capabilities-modal.component.html
+++ b/src/app/components/modals/capabilities-modal/capabilities-modal.component.html
@@ -1,25 +1,32 @@
 <!-- Capabilities Detail Modal -->
-<div class="modal fade" id="capabilityDetail" tabindex="-1" role="dialog" aria-labelledby="capabilityTitle"
-  aria-hidden="true">
+<div
+  class="modal fade"
+  id="capabilityDetail"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="capabilityTitle"
+  aria-hidden="true"
+>
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-royal-blue">
-        <a 
-          class="mr-3 text-white" 
-          role="button" 
-          aria-label="Previous" 
+        <a
+          class="mr-3 text-white"
+          role="button"
+          aria-label="Previous"
           tabindex="0"
-          (click)="tableService.previousModalRoute('capabilityDetail')" 
-          [hidden]="!modalService.checkModalRoutes()">
+          (click)="tableService.previousModalRoute('capabilityDetail')"
+          [hidden]="!modalService.checkModalRoutes()"
+        >
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="capabilityTitle">
           <i class="fas fa-project-diagram"></i>
           {{ capability.Name }} ({{ capability.ReferenceNum }})
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div class="modal-body">
@@ -27,15 +34,18 @@
         <ul id="capTabs" class="nav nav-tabs">
           <li class="nav-item">
             <a class="nav-link active" data-toggle="tab" href="#capOverview">
-              Overview</a>
+              Overview</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#capRelOrgs">
-              Related Organizations</a>
+              Related Organizations</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#capSupportSystems">
-              Supporting Systems</a>
+              Supporting Systems</a
+            >
           </li>
         </ul>
 
@@ -44,7 +54,7 @@
           <div class="tab-pane fade show active" id="capOverview">
             <h4>Description</h4>
             <p>{{ capability.Description }}</p>
-            <br><br>
+            <br /><br />
 
             <h4>Level</h4>
             <p>{{ capability.Level }}</p>
@@ -60,13 +70,18 @@
             <table id="capSupportSysTable"></table>
           </div>
           <!-- End of Support Systems Pane -->
-
         </div>
       </div>
 
       <div class="modal-footer">
-        <button type="button" [hidden]="!sharedService.loggedIn" class="btn btn-info text-white"
-          (click)="capabilityEdit()">Edit This Item</button>
+        <button
+          type="button"
+          [hidden]="!sharedService.loggedIn"
+          class="btn btn-info text-white"
+          (click)="capabilityEdit()"
+        >
+          Edit This Item
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/components/modals/capabilities-modal/capabilities-modal.component.html
+++ b/src/app/components/modals/capabilities-modal/capabilities-modal.component.html
@@ -4,8 +4,13 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-royal-blue">
-        <a class="mr-3 text-white" role="button" aria-label="Previous"
-          (click)="tableService.previousModalRoute('capabilityDetail')" [hidden]="!modalService.checkModalRoutes()">
+        <a 
+          class="mr-3 text-white" 
+          role="button" 
+          aria-label="Previous" 
+          tabindex="0"
+          (click)="tableService.previousModalRoute('capabilityDetail')" 
+          [hidden]="!modalService.checkModalRoutes()">
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="capabilityTitle">

--- a/src/app/components/modals/fisma-modal/fisma-modal.component.html
+++ b/src/app/components/modals/fisma-modal/fisma-modal.component.html
@@ -3,8 +3,13 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-warning">
-        <a class="mr-3 text-white" role="button" aria-label="Previous"
-          (click)="tableService.previousModalRoute('fismaDetail')" [hidden]="!modalService.checkModalRoutes()">
+        <a 
+          class="mr-3 text-white" 
+          role="button"
+          tabindex="0"
+          aria-label="Previous"
+          (click)="tableService.previousModalRoute('fismaDetail')" 
+          [hidden]="!modalService.checkModalRoutes()">
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="fismaTitle">

--- a/src/app/components/modals/fisma-modal/fisma-modal.component.html
+++ b/src/app/components/modals/fisma-modal/fisma-modal.component.html
@@ -1,24 +1,32 @@
 <!-- FISMA System Detail Modal -->
-<div class="modal fade" id="fismaDetail" tabindex="-1" role="dialog" aria-labelledby="fismaTitle" aria-hidden="true">
+<div
+  class="modal fade"
+  id="fismaDetail"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="fismaTitle"
+  aria-hidden="true"
+>
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-warning">
-        <a 
-          class="mr-3 text-white" 
+        <a
+          class="mr-3 text-white"
           role="button"
           tabindex="0"
           aria-label="Previous"
-          (click)="tableService.previousModalRoute('fismaDetail')" 
-          [hidden]="!modalService.checkModalRoutes()">
+          (click)="tableService.previousModalRoute('fismaDetail')"
+          [hidden]="!modalService.checkModalRoutes()"
+        >
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="fismaTitle">
           <i class="fas fa-shield-alt"></i>
           {{ fisma.Name }}
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div id="fismaTabs" class="modal-body">
@@ -26,7 +34,8 @@
         <ul class="nav nav-tabs">
           <li class="nav-item">
             <a class="nav-link active" data-toggle="tab" href="#fismaOverview">
-              Overview</a>
+              Overview</a
+            >
           </li>
           <!-- <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#subSystemsTab">
@@ -35,13 +44,19 @@
 
         <!-- Tab Panes -->
         <div class="tab-content mt-3">
-          <div class="container-fluid tab-pane fade show active" id="fismaOverview">
+          <div
+            class="container-fluid tab-pane fade show active"
+            id="fismaOverview"
+          >
             <div class="row">
               <div class="col-5">
                 <h4 class="text-center">System Overview</h4>
-                <br>
+                <br />
 
-                <table id="fismaOverviewTable" class="table table-striped table-dark rounded-lg">
+                <table
+                  id="fismaOverviewTable"
+                  class="table table-striped table-dark rounded-lg"
+                >
                   <thead class="bg-warning">
                     <tr>
                       <th>
@@ -56,7 +71,7 @@
                   <tbody>
                     <tr>
                       <td><i class="fa fa-calendar-alt"></i>ATO Date</td>
-                      <td>{{ fisma.ATODate | date:'longDate' }}</td>
+                      <td>{{ fisma.ATODate | date : "longDate" }}</td>
                     </tr>
                     <tr>
                       <td><i class="far fa-file"></i>ATO Type</td>
@@ -87,12 +102,18 @@
                         <i class="fa fa-file-alt"></i>Related Artifacts
                       </td>
                       <td>
-                        <ul [innerHTML]="tableService.renderRelArtifacts(fisma.RelatedArtifacts)"></ul>
+                        <ul
+                          [innerHTML]="
+                            tableService.renderRelArtifacts(
+                              fisma.RelatedArtifacts
+                            )
+                          "
+                        ></ul>
                       </td>
                     </tr>
                     <tr>
                       <td><i class="fa fa-calendar-alt"></i>Renewal Date</td>
-                      <td>{{ fisma.RenewalDate | date:'longDate' }}</td>
+                      <td>{{ fisma.RenewalDate | date : "longDate" }}</td>
                     </tr>
                     <tr>
                       <td><i class="fa fa-door-open"></i>Responsible Org</td>
@@ -114,9 +135,12 @@
               <!-- Points of Contact Table -->
               <div class="col-7">
                 <h4 class="text-center">Points of Contact</h4>
-                <br>
+                <br />
 
-                <table id="fismaPOCTable" class="table table-striped table-dark rounded-lg">
+                <table
+                  id="fismaPOCTable"
+                  class="table table-striped table-dark rounded-lg"
+                >
                   <thead class="bg-warning">
                     <tr>
                       <th>
@@ -134,7 +158,9 @@
                     </tr>
                   </thead>
 
-                  <tbody [innerHTML]="tableService.renderPOCInfoTable(fisma.POC)"></tbody>
+                  <tbody
+                    [innerHTML]="tableService.renderPOCInfoTable(fisma.POC)"
+                  ></tbody>
                 </table>
               </div>
               <!-- End ofPoints of Contact Table -->
@@ -146,7 +172,6 @@
             <table id="fismaSubSysTable"></table>
           </div> -->
           <!-- End of Sub-Systems Tab Pane -->
-
         </div>
         <!-- End of Tab Panes -->
       </div>

--- a/src/app/components/modals/investments-modal/investments-modal.component.html
+++ b/src/app/components/modals/investments-modal/investments-modal.component.html
@@ -1,24 +1,32 @@
 <!-- Investment Detail Modal -->
-<div class="modal fade" id="investDetail" tabindex="-1" role="dialog" aria-labelledby="investTitle" aria-hidden="true">
+<div
+  class="modal fade"
+  id="investDetail"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="investTitle"
+  aria-hidden="true"
+>
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-success">
-        <a 
-          class="mr-3 text-white" 
+        <a
+          class="mr-3 text-white"
           role="button"
           tabindex="0"
           aria-label="Previous"
-          (click)="tableService.previousModalRoute('investDetail')" 
-          [hidden]="!modalService.checkModalRoutes()">
+          (click)="tableService.previousModalRoute('investDetail')"
+          [hidden]="!modalService.checkModalRoutes()"
+        >
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="investTitle">
           <i class="fas fa-money-bill-wave"></i>
           {{ investment.Name }}
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div class="modal-body">
@@ -26,11 +34,14 @@
         <ul id="investTabs" class="nav nav-tabs">
           <li class="nav-item">
             <a class="nav-link active" data-toggle="tab" href="#investOverview">
-              Overview</a>
+              Overview</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#investRelatedSys">
-              Related Systems</a></li>
+              Related Systems</a
+            >
+          </li>
         </ul>
 
         <!-- Tab Panes -->
@@ -38,10 +49,12 @@
           <div class="tab-pane fade show active" id="investOverview">
             <h4>Description</h4>
             <p>{{ investment.Description }}</p>
-            <br>
+            <br />
 
-            <table id="investDetailTable"
-              class="table table-borderless table-striped table-dark rounded-lg w-75 mx-auto">
+            <table
+              id="investDetailTable"
+              class="table table-borderless table-striped table-dark rounded-lg w-75 mx-auto"
+            >
               <thead class="bg-success">
                 <tr>
                   <th>
@@ -67,7 +80,9 @@
                   <td>{{ investment.End_Year }}</td>
                 </tr>
                 <tr>
-                  <td><i class="fas fa-cloud"></i>Cloud Alternatives Evaluation</td>
+                  <td>
+                    <i class="fas fa-cloud"></i>Cloud Alternatives Evaluation
+                  </td>
                   <td>{{ investment.Cloud_Alt }}</td>
                 </tr>
                 <tr>
@@ -77,12 +92,16 @@
                 <tr>
                   <td><i class="fa fa-user"></i>Investment Manager</td>
                   <td>
-                    <a class="email text-white"
-                      href="https://mail.google.com/mail/?view=cm&fs=1&to={{ investment.InvManagerEmail }}"
-                      target="_blank" rel="noopener">{{ investment.InvManager }}</a>
-                    <div [hidden]="investment.InvManager">
-                      None Provided
-                    </div>
+                    <a
+                      class="email text-white"
+                      href="https://mail.google.com/mail/?view=cm&fs=1&to={{
+                        investment.InvManagerEmail
+                      }}"
+                      target="_blank"
+                      rel="noopener"
+                      >{{ investment.InvManager }}</a
+                    >
+                    <div [hidden]="investment.InvManager">None Provided</div>
                   </td>
                 </tr>
                 <tr>
@@ -94,13 +113,26 @@
                   <td>{{ investment.UII }}</td>
                 </tr>
                 <tr>
-                  <td><i class="far fa-folder-open"></i>Part of IT Portfolio</td>
+                  <td>
+                    <i class="far fa-folder-open"></i>Part of IT Portfolio
+                  </td>
                   <td>{{ investment.IT_Portfolio }}</td>
                 </tr>
                 <tr>
                   <td><i class="fa fa-th"></i>Primary Service Area</td>
-                  <td *ngIf="investment.PSA; else psaElse" class="btn-outline-info pointer"
-                  (click)="tableService.openRelated('#investDetail', investment.PSA, 'capability-name')">{{ investment.PSA }}</td>
+                  <td
+                    *ngIf="investment.PSA; else psaElse"
+                    class="btn-outline-info pointer"
+                    (click)="
+                      tableService.openRelated(
+                        '#investDetail',
+                        investment.PSA,
+                        'capability-name'
+                      )
+                    "
+                  >
+                    {{ investment.PSA }}
+                  </td>
                   <ng-template #psaElse>
                     <td>None Designated</td>
                   </ng-template>
@@ -111,19 +143,19 @@
                 </tr>
               </tbody>
             </table>
-
           </div>
           <!-- End of Overview Pane -->
 
           <div class="tab-pane fade" id="investRelatedSys">
             <table id="investRelSysTable"></table>
           </div>
-
         </div>
       </div>
 
       <div class="modal-footer">
-        <p class="font-weight-bold font-italic">Last Updated: {{ investment.Updated_Date | date:'MMM. dd, yyyy' }}</p>
+        <p class="font-weight-bold font-italic">
+          Last Updated: {{ investment.Updated_Date | date : "MMM. dd, yyyy" }}
+        </p>
       </div>
     </div>
   </div>

--- a/src/app/components/modals/investments-modal/investments-modal.component.html
+++ b/src/app/components/modals/investments-modal/investments-modal.component.html
@@ -3,8 +3,13 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-success">
-        <a class="mr-3 text-white" role="button" aria-label="Previous"
-          (click)="tableService.previousModalRoute('investDetail')" [hidden]="!modalService.checkModalRoutes()">
+        <a 
+          class="mr-3 text-white" 
+          role="button"
+          tabindex="0"
+          aria-label="Previous"
+          (click)="tableService.previousModalRoute('investDetail')" 
+          [hidden]="!modalService.checkModalRoutes()">
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="investTitle">

--- a/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
+++ b/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
@@ -4,8 +4,13 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-teal">
-        <a class="mr-3 text-white" role="button" aria-label="Previous"
-          (click)="tableService.previousModalRoute('itStandardDetail')" [hidden]="!modalService.checkModalRoutes()">
+        <a 
+          class="mr-3 text-white" 
+          role="button"
+          tabindex="0"
+          aria-label="Previous"
+          (click)="tableService.previousModalRoute('itStandardDetail')" 
+          [hidden]="!modalService.checkModalRoutes()">
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="itStandTitle">

--- a/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
+++ b/src/app/components/modals/it-standards-modal/it-standards-modal.component.html
@@ -1,37 +1,50 @@
 <!-- IT Standard Detail Modal -->
-<div class="modal fade" id="itStandardDetail" tabindex="-1" role="dialog" aria-labelledby="itStandTitle"
-  aria-hidden="true">
+<div
+  class="modal fade"
+  id="itStandardDetail"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="itStandTitle"
+  aria-hidden="true"
+>
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-teal">
-        <a 
-          class="mr-3 text-white" 
+        <a
+          class="mr-3 text-white"
           role="button"
           tabindex="0"
           aria-label="Previous"
-          (click)="tableService.previousModalRoute('itStandardDetail')" 
-          [hidden]="!modalService.checkModalRoutes()">
+          (click)="tableService.previousModalRoute('itStandardDetail')"
+          [hidden]="!modalService.checkModalRoutes()"
+        >
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="itStandTitle">
           <i class="fas fa-microchip"></i>
           {{ itStandard.Name }}
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div class="modal-body">
         <!-- Tabs -->
         <ul id="itStandTabs" class="nav nav-tabs">
           <li class="nav-item">
-            <a class="nav-link active" data-toggle="tab" href="#itStandOverview">
-              Overview</a>
+            <a
+              class="nav-link active"
+              data-toggle="tab"
+              href="#itStandOverview"
+            >
+              Overview</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#itStandRelatedSys">
-              Systems Using This Standard</a>
+              Systems Using This Standard</a
+            >
           </li>
         </ul>
 
@@ -40,11 +53,13 @@
           <div class="tab-pane fade show active" id="itStandOverview">
             <h4>Description</h4>
             <p>{{ itStandard.Description }}</p>
-            <br>
+            <br />
 
             <h4>Technology Overview</h4>
-            <table id="itStandDetailTable"
-              class="table table-borderless table-striped table-dark rounded-lg w-75 mx-auto">
+            <table
+              id="itStandDetailTable"
+              class="table table-borderless table-striped table-dark rounded-lg w-75 mx-auto"
+            >
               <thead class="bg-teal">
                 <tr>
                   <th>
@@ -58,12 +73,18 @@
 
               <tbody>
                 <tr>
-                  <td><i class="fas fa-universal-access"></i>508 Compliance Status</td>
+                  <td>
+                    <i class="fas fa-universal-access"></i>508 Compliance Status
+                  </td>
                   <td>{{ itStandard.ComplianceStatus }}</td>
                 </tr>
                 <tr>
-                  <td><i class="fa fa-calendar-alt"></i>Approval Expiration Date</td>
-                  <td>{{ itStandard.ApprovalExpirationDate | date:'MMMM d, y' }}</td>
+                  <td>
+                    <i class="fa fa-calendar-alt"></i>Approval Expiration Date
+                  </td>
+                  <td>
+                    {{ itStandard.ApprovalExpirationDate | date : "MMMM d, y" }}
+                  </td>
                 </tr>
                 <tr>
                   <td><i class="far fa-list-alt"></i>Category</td>
@@ -80,7 +101,11 @@
                 <tr>
                   <td><i class="fa fa-user"></i>POC</td>
                   <td>
-                    <ul [innerHTML]="sharedService.renderPOCInfoList(itStandard.POC)"></ul>
+                    <ul
+                      [innerHTML]="
+                        sharedService.renderPOCInfoList(itStandard.POC)
+                      "
+                    ></ul>
                   </td>
                 </tr>
                 <tr>
@@ -92,35 +117,49 @@
                   <td>{{ itStandard.Status }}</td>
                 </tr>
                 <tr>
-                  <td><i class="fas fa-sitemap"></i>Vendor Standard Organization</td>
+                  <td>
+                    <i class="fas fa-sitemap"></i>Vendor Standard Organization
+                  </td>
                   <td>{{ itStandard.Vendor_Standard_Organization }}</td>
                 </tr>
                 <tr>
                   <td><i class="far fa-comment"></i>Reference Document</td>
                   <td>
-                    <a [hidden]="!itStandard.ReferenceDocument" href="{{ itStandard.ReferenceDocument }}"
-                      target="_blank" rel="noopener">
-                      {{ itStandard.ReferenceDocument }}</a>
+                    <a
+                      [hidden]="!itStandard.ReferenceDocument"
+                      href="{{ itStandard.ReferenceDocument }}"
+                      target="_blank"
+                      rel="noopener"
+                    >
+                      {{ itStandard.ReferenceDocument }}</a
+                    >
                     <div [hidden]="itStandard.ReferenceDocument">None</div>
                   </td>
                 </tr>
               </tbody>
             </table>
-
           </div>
           <!-- End of Overview Pane -->
 
           <div class="tab-pane fade" id="itStandRelatedSys">
             <table id="itRelSysTable"></table>
           </div>
-
         </div>
       </div>
 
       <div class="modal-footer">
-        <div class="float-right">Last Updated: {{ itStandard.ChangeDTG | date:'MMM d, y, h:mm:ss a O' }}</div>
-        <button type="button" [hidden]="!sharedService.loggedIn" class="btn btn-info text-white"
-          (click)="itStandEdit()">Edit This Item</button>
+        <div class="float-right">
+          Last Updated:
+          {{ itStandard.ChangeDTG | date : "MMM d, y, h:mm:ss a O" }}
+        </div>
+        <button
+          type="button"
+          [hidden]="!sharedService.loggedIn"
+          class="btn btn-info text-white"
+          (click)="itStandEdit()"
+        >
+          Edit This Item
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/components/modals/organizations-modal/organizations-modal.component.html
+++ b/src/app/components/modals/organizations-modal/organizations-modal.component.html
@@ -1,25 +1,32 @@
 <!-- Organizations Detail Modal -->
-<div class="modal fade" id="organizationDetail" tabindex="-1" role="dialog" aria-labelledby="orgTitle"
-  aria-hidden="true">
+<div
+  class="modal fade"
+  id="organizationDetail"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="orgTitle"
+  aria-hidden="true"
+>
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-royal-blue">
-        <a 
-          class="mr-3 text-white" 
-          role="button" 
+        <a
+          class="mr-3 text-white"
+          role="button"
           tabindex="0"
           aria-label="Previous"
-          (click)="tableService.previousModalRoute('organizationDetail')" 
-          [hidden]="!modalService.checkModalRoutes()">
+          (click)="tableService.previousModalRoute('organizationDetail')"
+          [hidden]="!modalService.checkModalRoutes()"
+        >
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="orgTitle">
           <i class="fas fa-sitemap"></i>
           {{ org.Name }} ({{ org.OrgSymbol }})
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div class="modal-body">
@@ -27,15 +34,18 @@
         <ul id="orgTabs" class="nav nav-tabs">
           <li class="nav-item">
             <a class="nav-link active" data-toggle="tab" href="#orgOverview">
-              Overview</a>
+              Overview</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#orgCaps">
-              Related Capabilities</a>
+              Related Capabilities</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#orgSys">
-              Organizational Systems</a>
+              Organizational Systems</a
+            >
           </li>
         </ul>
 
@@ -76,7 +86,6 @@
             <table id="orgSysTable"></table>
           </div>
           <!-- End of Supporting Systems Pane -->
-
         </div>
       </div>
 

--- a/src/app/components/modals/organizations-modal/organizations-modal.component.html
+++ b/src/app/components/modals/organizations-modal/organizations-modal.component.html
@@ -4,8 +4,13 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-royal-blue">
-        <a class="mr-3 text-white" role="button" aria-label="Previous"
-          (click)="tableService.previousModalRoute('organizationDetail')" [hidden]="!modalService.checkModalRoutes()">
+        <a 
+          class="mr-3 text-white" 
+          role="button" 
+          tabindex="0"
+          aria-label="Previous"
+          (click)="tableService.previousModalRoute('organizationDetail')" 
+          [hidden]="!modalService.checkModalRoutes()">
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="orgTitle">

--- a/src/app/components/modals/records-modal/records-modal.component.html
+++ b/src/app/components/modals/records-modal/records-modal.component.html
@@ -1,36 +1,50 @@
 <!-- Record Detail Modal -->
-<div class="modal fade" id="recordDetail" tabindex="-1" role="dialog" aria-labelledby="recordTitle" aria-hidden="true">
+<div
+  class="modal fade"
+  id="recordDetail"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="recordTitle"
+  aria-hidden="true"
+>
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-danger">
-        <a 
-          class="mr-3 text-white" 
-          role="button" 
+        <a
+          class="mr-3 text-white"
+          role="button"
           tabindex="0"
           aria-label="Previous"
-          (click)="tableService.previousModalRoute('recordDetail')" 
-          [hidden]="!modalService.checkModalRoutes()">
+          (click)="tableService.previousModalRoute('recordDetail')"
+          [hidden]="!modalService.checkModalRoutes()"
+        >
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="recordTitle">
           <i class="far fa-folder-open"></i>
           {{ record.Record_Item_Title }}
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div class="modal-body">
         <!-- Tabs -->
         <ul id="recordTabs" class="nav nav-tabs">
           <li class="nav-item">
-            <a class="nav-link active" data-toggle="tab" href="#recordsOverview">
-              Overview</a>
+            <a
+              class="nav-link active"
+              data-toggle="tab"
+              href="#recordsOverview"
+            >
+              Overview</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#recRelatedSystems">
-              Related Systems</a>
+              Related Systems</a
+            >
           </li>
         </ul>
 
@@ -39,28 +53,26 @@
           <div class="tab-pane fade show active" id="recordsOverview">
             <h4>Description</h4>
             <p>{{ record.Description }}</p>
-            <br>
+            <br />
 
             <h4>Retention Instructions</h4>
             <div>
               <p>{{ record.Retention_Instructions }}</p>
             </div>
-            <div [hidden]="record.Retention_Instructions">
-              None
-            </div>
-            <br>
+            <div [hidden]="record.Retention_Instructions">None</div>
+            <br />
 
             <h4>Disposition Notes</h4>
             <div>
               <p>{{ record.Disposition_Notes }}</p>
             </div>
-            <div [hidden]="record.Disposition_Notes">
-              None
-            </div>
-            <br>
+            <div [hidden]="record.Disposition_Notes">None</div>
+            <br />
 
-            <table id="recordDetailTable"
-              class="table table-borderless table-striped table-dark rounded-lg w-75 mx-auto">
+            <table
+              id="recordDetailTable"
+              class="table table-borderless table-striped table-dark rounded-lg w-75 mx-auto"
+            >
               <thead class="bg-danger">
                 <tr>
                   <th>
@@ -77,7 +89,7 @@
                   <td><i class="fa fa-bookmark"></i>CUI Indicator</td>
                   <td>{{ record.CUI }}</td>
                 </tr>
-				<tr>
+                <tr>
                   <td><i class="fa fa-bookmark"></i>Retention Years</td>
                   <td>{{ record.FY_Retention_Years }}</td>
                 </tr>
@@ -131,8 +143,14 @@
       <!-- End of Modal Body -->
 
       <div class="modal-footer">
-        <button type="button" [hidden]="!sharedService.loggedIn" class="btn btn-info text-white"
-          (click)="recordEdit()">Edit This Item</button>
+        <button
+          type="button"
+          [hidden]="!sharedService.loggedIn"
+          class="btn btn-info text-white"
+          (click)="recordEdit()"
+        >
+          Edit This Item
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/components/modals/records-modal/records-modal.component.html
+++ b/src/app/components/modals/records-modal/records-modal.component.html
@@ -3,8 +3,13 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-danger">
-        <a class="mr-3 text-white" role="button" aria-label="Previous"
-          (click)="tableService.previousModalRoute('recordDetail')" [hidden]="!modalService.checkModalRoutes()">
+        <a 
+          class="mr-3 text-white" 
+          role="button" 
+          tabindex="0"
+          aria-label="Previous"
+          (click)="tableService.previousModalRoute('recordDetail')" 
+          [hidden]="!modalService.checkModalRoutes()">
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="recordTitle">

--- a/src/app/components/modals/service-category-modal/service-category-modal.component.html
+++ b/src/app/components/modals/service-category-modal/service-category-modal.component.html
@@ -24,14 +24,9 @@
           <i class="fas fa-project-diagram"></i>
           {{ serviceCategory.name }}
         </h5>
-        <button
-          type="button"
-          class="close"
-          data-dismiss="modal"
-          aria-label="Close"
-        >
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div class="modal-body">

--- a/src/app/components/modals/service-category-modal/service-category-modal.component.html
+++ b/src/app/components/modals/service-category-modal/service-category-modal.component.html
@@ -14,6 +14,7 @@
           class="mr-3 text-white"
           role="button"
           aria-label="Previous"
+          tabindex="0"
           (click)="tableService.previousModalRoute('serviceCategoryDetail')"
           [hidden]="!modalService.checkModalRoutes()"
         >

--- a/src/app/components/modals/service-category-modal/service-category-modal.component.html
+++ b/src/app/components/modals/service-category-modal/service-category-modal.component.html
@@ -1,10 +1,10 @@
-<!-- Capabilities Detail Modal -->
+<!-- Service Category Detail Modal -->
 <div
   class="modal fade"
   id="serviceCategoryDetail"
   tabindex="-1"
   role="dialog"
-  aria-labelledby="capabilityTitle"
+  aria-labelledby="serviceCategoryTitle"
   aria-hidden="true"
 >
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
@@ -36,27 +36,21 @@
 
       <div class="modal-body">
         <!-- Tabs -->
-        <ul id="capTabs" class="nav nav-tabs">
+        <ul id="serviceCategoryTabs" class="nav nav-tabs">
           <li class="nav-item">
-            <a class="nav-link active" data-toggle="tab" href="#capOverview">
+            <a
+              class="nav-link active"
+              data-toggle="tab"
+              href="#serviceCategoryOverview"
+            >
               Overview</a
-            >
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" data-toggle="tab" href="#capRelOrgs">
-              Related Organizations</a
-            >
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" data-toggle="tab" href="#capSupportSystems">
-              Supporting Systems</a
             >
           </li>
         </ul>
 
         <!-- Tab Panes -->
         <div class="tab-content mt-3">
-          <div class="tab-pane fade show active" id="capOverview">
+          <div class="tab-pane fade show active" id="serviceCategoryOverview">
             <div class="card-body card-text">
               <div class="row">
                 <div class="col-12 col-md-6">

--- a/src/app/components/modals/systems-modal/systems-modal.component.html
+++ b/src/app/components/modals/systems-modal/systems-modal.component.html
@@ -1,24 +1,32 @@
 <!-- Systems Detail Modal -->
-<div class="modal fade" id="systemDetail" tabindex="-1" role="dialog" aria-labelledby="systemTitle" aria-hidden="true">
+<div
+  class="modal fade"
+  id="systemDetail"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="systemTitle"
+  aria-hidden="true"
+>
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-danger">
-        <a 
-          class="mr-3 text-white" 
+        <a
+          class="mr-3 text-white"
           role="button"
           tabindex="0"
           aria-label="Previous"
-          (click)="tableService.previousModalRoute('systemDetail')" 
-          [hidden]="!modalService.checkModalRoutes()">
+          (click)="tableService.previousModalRoute('systemDetail')"
+          [hidden]="!modalService.checkModalRoutes()"
+        >
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="systemTitle">
           <i class="fas fa-desktop"></i>
           {{ system.Name }}
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div id="systemTabs" class="modal-body">
@@ -26,27 +34,33 @@
         <ul class="nav nav-tabs">
           <li class="nav-item">
             <a class="nav-link active" data-toggle="tab" href="#systemOverview">
-              Overview</a>
+              Overview</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#businessRelated">
-              Business</a>
+              Business</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#technicalRelated">
-              Technical</a>
+              Technical</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#relatedInvestments">
-              Related Investments</a>
+              Related Investments</a
+            >
           </li>
           <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#relatedRecords">
-              Related Records</a>
+              Related Records</a
+            >
           </li>
           <li class="nav-item" [hidden]="system.SystemLevel != 'System'">
             <a class="nav-link" data-toggle="tab" href="#systemSubs">
-              Subsystems</a>
+              Subsystems</a
+            >
           </li>
           <!-- <li class="nav-item" [hidden]="!interfaces.length">
             <a class="nav-link" data-toggle="tab" href="#systemDataFlow">
@@ -56,7 +70,6 @@
         <!-- Tab Panes -->
         <div class="tab-content mt-3">
           <div class="tab-pane fade show active" id="systemOverview">
-
             <div class="row mb-4">
               <div class="col">
                 <h4>Alias/Acronym</h4>
@@ -76,10 +89,14 @@
 
             <h4>Description</h4>
             <p>{{ system.Description }}</p>
-            <br><br>
+            <br /><br />
 
             <h4>Related Artifacts</h4>
-            <ul [innerHTML]="tableService.renderRelArtifacts(system.RelatedArtifacts)"></ul>
+            <ul
+              [innerHTML]="
+                tableService.renderRelArtifacts(system.RelatedArtifacts)
+              "
+            ></ul>
             <p [hidden]="system.RelatedArtifacts">None</p>
           </div>
           <!-- End of Overview Tab Pane -->
@@ -88,9 +105,12 @@
             <div class="row">
               <div class="col-5">
                 <h4 class="text-center">Business Overview</h4>
-                <br>
+                <br />
 
-                <table id="systemBusinessTable" class="table table-borderless table-striped table-dark rounded-lg">
+                <table
+                  id="systemBusinessTable"
+                  class="table table-borderless table-striped table-dark rounded-lg"
+                >
                   <thead class="bg-danger">
                     <tr>
                       <th>
@@ -105,7 +125,7 @@
                   <tbody>
                     <tr>
                       <td><i class="far fa-calendar-check"></i>ATO Date</td>
-                      <td>{{ system.ATODate | date:'longDate' }}</td>
+                      <td>{{ system.ATODate | date : "longDate" }}</td>
                     </tr>
                     <tr>
                       <td><i class="far fa-folder-open"></i>ATO Type</td>
@@ -124,7 +144,7 @@
                     </tr>
                     <tr *ngIf="system.InactiveDate">
                       <td><i class="fa fa-calendar-alt"></i>Inactive Date</td>
-                      <td>{{ system.InactiveDate | date:'longDate' }}</td>
+                      <td>{{ system.InactiveDate | date : "longDate" }}</td>
                     </tr>
                     <!-- <tr>
                       <td><i class="fas fa-money-bill-wave"></i>Investment</td>
@@ -136,7 +156,7 @@
                     </tr> -->
                     <tr *ngIf="system.RenewalDate">
                       <td><i class="fas fa-calendar-day"></i>Renewal Date</td>
-                      <td>{{ system.RenewalDate | date:'longDate' }}</td>
+                      <td>{{ system.RenewalDate | date : "longDate" }}</td>
                     </tr>
                     <tr>
                       <td><i class="fa fa-sitemap"></i>Responsible IT Org</td>
@@ -157,9 +177,12 @@
               <!-- Points of Contact Table -->
               <div class="col-7">
                 <h4 class="text-center">Points of Contact</h4>
-                <br>
+                <br />
 
-                <table id="fismaPOCTable" class="table table-striped table-dark rounded-lg">
+                <table
+                  id="fismaPOCTable"
+                  class="table table-striped table-dark rounded-lg"
+                >
                   <thead class="bg-danger">
                     <tr>
                       <th>
@@ -177,7 +200,9 @@
                     </tr>
                   </thead>
 
-                  <tbody [innerHTML]="tableService.renderPOCInfoTable(system.POC)"></tbody>
+                  <tbody
+                    [innerHTML]="tableService.renderPOCInfoTable(system.POC)"
+                  ></tbody>
                 </table>
               </div>
             </div>
@@ -189,13 +214,18 @@
                 <div class="text-center mt-3">
                   <h4>System TIME Report</h4>
                   <!-- TIME Definitions Link -->
-                  <a type="button" class="btn btn-sm btn-info text-white" [routerLink]="['/about', 'sysRat']"
-                    target="_blank">TIME Value Definitions</a>
+                  <a
+                    type="button"
+                    class="btn btn-sm btn-info text-white"
+                    [routerLink]="['/about', 'sysRat']"
+                    target="_blank"
+                    >TIME Value Definitions</a
+                  >
                 </div>
 
                 <table id="sysTimeTable"></table>
               </div>
-              <br>
+              <br />
 
               <!-- Related Business Capabilities Table -->
               <div>
@@ -208,9 +238,12 @@
 
           <div class="tab-pane fade" id="technicalRelated">
             <h4 class="text-center">Technical Overview</h4>
-            <br>
+            <br />
 
-            <table id="techAttrTable" class="table table-borderless table-striped table-dark rounded-lg w-50 mx-auto">
+            <table
+              id="techAttrTable"
+              class="table table-borderless table-striped table-dark rounded-lg w-50 mx-auto"
+            >
               <thead class="bg-danger">
                 <tr>
                   <th>
@@ -232,7 +265,10 @@
                   <td>{{ system.CSP }}</td>
                 </tr>
                 <tr>
-                  <td><i class="fa fa-bookmark"></i>Complete FISMA Assessment for Current FY</td>
+                  <td>
+                    <i class="fa fa-bookmark"></i>Complete FISMA Assessment for
+                    Current FY
+                  </td>
                   <td>{{ system.ComplFISMA }}</td>
                 </tr>
                 <tr>
@@ -240,7 +276,9 @@
                   <td>{{ system.FIPS_Impact_Level }}</td>
                 </tr>
                 <tr>
-                  <td><i class="far fa-handshake"></i>Gov't-Wide Shared Service</td>
+                  <td>
+                    <i class="far fa-handshake"></i>Gov't-Wide Shared Service
+                  </td>
                   <td>{{ system.SharedService }}</td>
                 </tr>
                 <tr>
@@ -265,7 +303,7 @@
                 </tr> -->
               </tbody>
             </table>
-            <br>
+            <br />
 
             <!-- Related Technologies Table -->
             <div>
@@ -295,15 +333,20 @@
             <!-- <div id="dataFlowChart" class="text-center"></div> -->
           </div>
           <!-- End of Data Flow Tab Pane -->
-
         </div>
         <!-- End of Tab Panes -->
       </div>
       <!-- End of Modal Body -->
 
       <div class="modal-footer">
-        <button type="button" [hidden]="!sharedService.loggedIn" class="btn btn-info text-white"
-          (click)="systemEdit()">Edit This Item</button>
+        <button
+          type="button"
+          [hidden]="!sharedService.loggedIn"
+          class="btn btn-info text-white"
+          (click)="systemEdit()"
+        >
+          Edit This Item
+        </button>
       </div>
     </div>
   </div>

--- a/src/app/components/modals/systems-modal/systems-modal.component.html
+++ b/src/app/components/modals/systems-modal/systems-modal.component.html
@@ -3,8 +3,13 @@
   <div class="modal-dialog modal-dialog-scrollable modal-xl">
     <div class="modal-content">
       <div class="modal-header bg-danger">
-        <a class="mr-3 text-white" role="button" aria-label="Previous"
-          (click)="tableService.previousModalRoute('systemDetail')" [hidden]="!modalService.checkModalRoutes()">
+        <a 
+          class="mr-3 text-white" 
+          role="button"
+          tabindex="0"
+          aria-label="Previous"
+          (click)="tableService.previousModalRoute('systemDetail')" 
+          [hidden]="!modalService.checkModalRoutes()">
           <i class="fas fa-arrow-circle-left fa-lg fa-fw"></i>
         </a>
         <h5 class="modal-title text-white" id="systemTitle">

--- a/src/app/components/modals/websites-modal/websites-modal.component.css
+++ b/src/app/components/modals/websites-modal/websites-modal.component.css
@@ -1,3 +1,8 @@
+/* Service Category Badges */
+span.pointer {
+  cursor: pointer;
+}
+/* Website chart */
 .legend {
   height: 25px;
   width: 25px;

--- a/src/app/components/modals/websites-modal/websites-modal.component.html
+++ b/src/app/components/modals/websites-modal/websites-modal.component.html
@@ -114,7 +114,9 @@
                   <span
                     *ngFor="let sc of serviceCategories"
                     (click)="serviceCategoryClick(sc.service_category_id)"
-                    (keydown.enter)="serviceCategoryClick(sc.service_category_id)"
+                    (keydown.enter)="
+                      serviceCategoryClick(sc.service_category_id)
+                    "
                     class="badge badge-info p-3 mr-2 pointer"
                     tabindex="0"
                     role="link"
@@ -137,11 +139,22 @@
                       viewBox="0 0 100 100"
                       xmlns="http://www.w3.org/2000/svg"
                     >
+                      <title>
+                        Coxcomb chart showing website strengths and weaknesses
+                        on a 0 to 1 scale with 1 being the highest value. Scores
+                        are as follows: Customer Centricity:
+                        {{ website.customer_centricity }}, Required Links:
+                        {{ website.required_links }}, Mobile Performance:
+                        {{ website.mobile_performance }}, Accessibility:
+                        {{ website.accessibility }}, Google Analytics:
+                        {{ website.google_analytics }}, USWDS:
+                        {{ website.uswds }}
+                      </title>
                       <g class="background">
                         <circle cx="50" cy="50" r="50" pathLength="100" />
                       </g>
 
-                      <g id="website-chart" class="graph" >
+                      <g id="website-chart" class="graph">
                         <circle
                           cx="50"
                           cy="50"

--- a/src/app/components/modals/websites-modal/websites-modal.component.html
+++ b/src/app/components/modals/websites-modal/websites-modal.component.html
@@ -113,7 +113,10 @@
                   <span
                     *ngFor="let sc of serviceCategories"
                     (click)="serviceCategoryClick(sc.service_category_id)"
-                    class="badge badge-info p-3 mr-2"
+                    (keydown.enter)="serviceCategoryClick(sc.service_category_id)"
+                    class="badge badge-info p-3 mr-2 pointer"
+                    tabindex="0"
+                    role="link"
                     >{{ sc.name }}</span
                   >
                 </div>
@@ -137,7 +140,7 @@
                         <circle cx="50" cy="50" r="50" pathLength="100" />
                       </g>
 
-                      <g id="website-chart" class="graph">
+                      <g id="website-chart" class="graph" >
                         <circle
                           cx="50"
                           cy="50"

--- a/src/app/components/modals/websites-modal/websites-modal.component.html
+++ b/src/app/components/modals/websites-modal/websites-modal.component.html
@@ -14,6 +14,7 @@
           class="mr-3 text-white"
           role="button"
           aria-label="Previous"
+          tabindex="0"
           (click)="tableService.previousModalRoute('websiteDetail')"
           [hidden]="!modalService.checkModalRoutes()"
         >

--- a/src/app/components/modals/websites-modal/websites-modal.component.html
+++ b/src/app/components/modals/websites-modal/websites-modal.component.html
@@ -25,14 +25,9 @@
           {{ website.domain }}
           <!-- This refers to api/queries/GET name of object in database -->
         </h5>
-        <button
-          type="button"
-          class="close"
-          data-dismiss="modal"
-          aria-label="Close"
-        >
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <a role="button" aria-label="Close" data-dismiss="modal" tabindex="0">
+          <i class="fas fa-times fa-lg text-white align-self-center"></i>
+        </a>
       </div>
 
       <div class="modal-body">

--- a/src/app/components/modals/websites-modal/websites-modal.component.ts
+++ b/src/app/components/modals/websites-modal/websites-modal.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -27,7 +28,8 @@ export class WebsitesModalComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     public sharedService: SharedService,
-    public tableService: TableService
+    public tableService: TableService,
+    private titleService: Title
   ) {}
 
   // Website scan Table Options
@@ -85,6 +87,9 @@ export class WebsitesModalComponent implements OnInit {
           (websiteServiceCategories) =>
             (this.serviceCategories = websiteServiceCategories)
         );
+      this.titleService.setTitle(
+        `${this.titleService.getTitle()} / ${this.website.Website_ID}`
+      );
     });
 
     $('#websitesRelSysTable').bootstrapTable(

--- a/src/app/components/modals/websites-modal/websites-modal.component.ts
+++ b/src/app/components/modals/websites-modal/websites-modal.component.ts
@@ -87,9 +87,6 @@ export class WebsitesModalComponent implements OnInit {
           (websiteServiceCategories) =>
             (this.serviceCategories = websiteServiceCategories)
         );
-      this.titleService.setTitle(
-        `${this.titleService.getTitle()} / ${this.website.Website_ID}`
-      );
     });
 
     $('#websitesRelSysTable').bootstrapTable(

--- a/src/app/components/top-navbar/top-navbar.component.html
+++ b/src/app/components/top-navbar/top-navbar.component.html
@@ -1,28 +1,55 @@
-<nav class="navbar navbar-expand-xl2 fixed-top navbar-dark bg-primary shadow-lg p-1" id="topNav" role="navigation">
-
+<nav
+  class="navbar navbar-expand-xl2 fixed-top navbar-dark bg-primary shadow-lg p-1"
+  id="topNav"
+  role="navigation"
+>
   <a class="navbar-brand ml-3" routerLink="/">
     <i class="fas fa-cogs fa-lg"></i>
     GSA EA Analytics & Reporting (GEAR)
     <span [innerHTML]="envName"></span>
-    <span *ngIf="sharedService.loggedIn" style="color: red"> **GEAR Manager Mode**</span>
+    <span *ngIf="sharedService.loggedIn" style="color: red">
+      **GEAR Manager Mode**</span
+    >
   </a>
 
   <!-- Global Search -->
   <div class="d-flex flex-nowrap justify-content-center">
     <form class="form-inline" role="search">
-      <input type="search" name="globalSearchField" [(ngModel)]="searchKW" class="form-control mr-2"
-        placeholder="Global Search" (keydown)="globalSearch($event)">
+      <label for="globalSearch" class="sr-only sr-only-focusable"
+        >Global Search</label
+      >
+      <input
+        type="search"
+        id="globalSearch"
+        name="globalSearchField"
+        [(ngModel)]="searchKW"
+        class="form-control mr-2"
+        placeholder="Global Search"
+        (keydown)="globalSearch($event)"
+      />
       <!-- Weird bug where if button isn't here, hitting enter will not execute and update search table at first. Leaving button here -->
-      <button name="globalSearchBttn" aria-label="Global Search Button" class="btn btn-light form-control"
-        (click)="globalSearch($event)" hidden>
+      <button
+        name="globalSearchBttn"
+        aria-label="Global Search Button"
+        class="btn btn-light form-control"
+        (click)="globalSearch($event)"
+        hidden
+      >
         <i class="fas fa-search fa-lg"></i>
       </button>
     </form>
   </div>
 
-  <button (click)="toggleTopNavBttn()" class="navbar-toggler" type="button"
-    data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
-    aria-expanded="false" aria-label="Toggle Top Navigation">
+  <button
+    (click)="toggleTopNavBttn()"
+    class="navbar-toggler"
+    type="button"
+    data-toggle="collapse"
+    data-target="#navbarSupportedContent"
+    aria-controls="navbarSupportedContent"
+    aria-expanded="false"
+    aria-label="Toggle Top Navigation"
+  >
     More Links <i id="topNavToggle" class="fas fa-angle-down ml-2 rotate"></i>
   </button>
 
@@ -34,25 +61,45 @@
       </li>
 
       <li class="nav-item">
-        <a id="assistTechBttn" class="nav-link" routerLink="/assist_tech">Assitive Technology</a>
+        <a id="assistTechBttn" class="nav-link" routerLink="/assist_tech"
+          >Assitive Technology</a
+        >
       </li>
 
       <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" id="contactDropdown" data-toggle="dropdown" aria-haspopup="true"
-          aria-expanded="false">Contact/Feedback</a>
-        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="contactDropdown">
-      <li class="dropdown-header">Regarding IT Standards</li>
-      <a class="dropdown-item" href="https://mail.google.com/mail/?view=cm&fs=1&to=it-standards@gsa.gov" target="_blank"
-        rel="noopener">IT Standards</a>
+        <a
+          class="nav-link dropdown-toggle"
+          id="contactDropdown"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+          >Contact/Feedback</a
+        >
+        <div
+          class="dropdown-menu dropdown-menu-right"
+          aria-labelledby="contactDropdown"
+        >
+          <li class="dropdown-header">Regarding IT Standards</li>
+          <a
+            class="dropdown-item"
+            href="https://mail.google.com/mail/?view=cm&fs=1&to=it-standards@gsa.gov"
+            target="_blank"
+            rel="noopener"
+            >IT Standards</a
+          >
 
-      <div class="dropdown-divider"></div>
+          <div class="dropdown-divider"></div>
 
-      <li class="dropdown-header">Regarding GEAR/EA</li>
-      <a class="dropdown-item" href="https://mail.google.com/mail/?view=cm&fs=1&to=ea_planning@gsa.gov" target="_blank"
-        rel="noopener">EA Team</a>
-  </div>
-  </li>
-
-  </ul>
+          <li class="dropdown-header">Regarding GEAR/EA</li>
+          <a
+            class="dropdown-item"
+            href="https://mail.google.com/mail/?view=cm&fs=1&to=ea_planning@gsa.gov"
+            target="_blank"
+            rel="noopener"
+            >EA Team</a
+          >
+        </div>
+      </li>
+    </ul>
   </div>
 </nav>

--- a/src/app/components/top-navbar/top-navbar.component.html
+++ b/src/app/components/top-navbar/top-navbar.component.html
@@ -6,7 +6,7 @@
   <a class="navbar-brand ml-3" routerLink="/">
     <i class="fas fa-cogs fa-lg"></i>
     GSA EA Analytics & Reporting (GEAR)
-    <span [innerHTML]="envName"></span>
+    <span [innerHTML]="envName" style="color: var(--pink)"></span>
     <span *ngIf="sharedService.loggedIn" style="color: red">
       **GEAR Manager Mode**</span
     >

--- a/src/app/components/top-navbar/top-navbar.component.ts
+++ b/src/app/components/top-navbar/top-navbar.component.ts
@@ -24,7 +24,7 @@ export class TopNavbarComponent implements OnInit {
     public sharedService: SharedService
   ) {
     if (environment.name !== 'Production') {
-      this.envName = `<span style="color: var(--pink)"> - ${environment.name.toUpperCase()} ENVIRONMENT</span>`;
+      this.envName = `<span> - ${environment.name.toUpperCase()} ENVIRONMENT</span>`;
     }
   }
 

--- a/src/app/components/top-navbar/top-navbar.component.ts
+++ b/src/app/components/top-navbar/top-navbar.component.ts
@@ -12,33 +12,34 @@ declare var $: any;
 @Component({
   selector: 'top-navbar',
   templateUrl: './top-navbar.component.html',
-  styleUrls: ['./top-navbar.component.css']
+  styleUrls: ['./top-navbar.component.css'],
 })
 export class TopNavbarComponent implements OnInit {
-
   public envName: string = '';
   public searchKW: string = '';
 
   constructor(
     private apiService: ApiService,
     private router: Router,
-    public sharedService: SharedService) {
-      if (environment.name !== 'Production') {
-        this.envName = `<span class="text-danger"> - ${environment.name.toUpperCase()} ENVIRONMENT</span>`;
-      };
+    public sharedService: SharedService
+  ) {
+    if (environment.name !== 'Production') {
+      this.envName = `<span style="color: var(--pink)"> - ${environment.name.toUpperCase()} ENVIRONMENT</span>`;
     }
-
-  ngOnInit(): void {
   }
 
+  ngOnInit(): void {}
+
   globalSearch(event) {
-    if (event.key === "Enter" || event.type === "click") {
+    if (event.key === 'Enter' || event.type === 'click') {
       $('#globalSearchTable').bootstrapTable('refreshOptions', {
         exportOptions: {
-          fileName: this.sharedService.fileNameFmt('GEAR_Global_Search-' + this.searchKW)
+          fileName: this.sharedService.fileNameFmt(
+            'GEAR_Global_Search-' + this.searchKW
+          ),
         },
-        url: this.apiService.globalSearchUrl + this.searchKW
-      })
+        url: this.apiService.globalSearchUrl + this.searchKW,
+      });
 
       this.router.navigate([`/search`]);
     }
@@ -46,7 +47,6 @@ export class TopNavbarComponent implements OnInit {
 
   // Toggle arrow rotation when top navbar collapse button is clicked
   toggleTopNavBttn() {
-    $("#topNavToggle").toggleClass("opposite");
+    $('#topNavToggle').toggleClass('opposite');
   }
-
 }

--- a/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
+++ b/src/app/views/enterprise/capabilities-model/capabilities-model.component.ts
@@ -1,10 +1,11 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { ApiService } from "@services/apis/api.service";
+import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare D3 library
 declare var d3: any;
@@ -23,10 +24,9 @@ interface CapTree {
 @Component({
   selector: 'capabilities-model',
   templateUrl: './capabilities-model.component.html',
-  styleUrls: ['./capabilities-model.component.css']
+  styleUrls: ['./capabilities-model.component.css'],
 })
 export class CapabilitiesModelComponent implements OnInit {
-
   @ViewChild('busCapGraph') public graphContainer: ElementRef;
   private caps: any[] = [];
   private root: any = {};
@@ -48,13 +48,15 @@ export class CapabilitiesModelComponent implements OnInit {
     private modalService: ModalsService,
     private route: ActivatedRoute,
     private sharedService: SharedService,
-    private tableService: TableService) { }
+    private tableService: TableService,
+    private titleService: Title
+  ) {}
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
     // Set JWT when logged into GEAR Manager when returning from secureAuth
     this.sharedService.setJWTonLogIn();
@@ -62,13 +64,13 @@ export class CapabilitiesModelComponent implements OnInit {
     this.getCapData();
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailCapID = params['capID'];
       if (detailCapID) {
         this.apiService.getOneCap(detailCapID).subscribe((data: any[]) => {
           this.tableService.capsTableClick(data[0]);
         });
-      };
+      }
     });
   }
 
@@ -79,7 +81,7 @@ export class CapabilitiesModelComponent implements OnInit {
       this.caps = data;
 
       // Set Root Node
-      this.caps.forEach(cap => {
+      this.caps.forEach((cap) => {
         if (cap.Name == this.rootCap) {
           this.capTree = {
             identity: cap.ID,
@@ -87,13 +89,13 @@ export class CapabilitiesModelComponent implements OnInit {
             description: cap.Description,
             referenceNum: cap.ReferenceNum,
             level: cap.Level,
-            children: []
-          }
-        };
+            children: [],
+          };
+        }
       });
 
       // Set First-Level Children
-      this.caps.forEach(cap => {
+      this.caps.forEach((cap) => {
         if (cap.Parent == this.capTree.name) {
           this.capTree.children.push({
             identity: cap.ID,
@@ -101,15 +103,14 @@ export class CapabilitiesModelComponent implements OnInit {
             description: cap.Description,
             referenceNum: cap.ReferenceNum,
             level: cap.Level,
-            children: []
+            children: [],
           });
         }
       });
 
       // Set Second-Level Children
-      this.capTree.children.forEach(firstLevelCap => {
-
-        this.caps.forEach(cap => {
+      this.capTree.children.forEach((firstLevelCap) => {
+        this.caps.forEach((cap) => {
           if (cap.Parent == firstLevelCap.name) {
             firstLevelCap.children.push({
               identity: cap.ID,
@@ -117,18 +118,16 @@ export class CapabilitiesModelComponent implements OnInit {
               description: cap.Description,
               referenceNum: cap.ReferenceNum,
               level: cap.Level,
-              children: []
+              children: [],
             });
           }
         });
-
       });
 
       // Set Third-Level Children
-      this.capTree.children.forEach(firstLevelCap => {
-        firstLevelCap.children.forEach(secondLevelCap => {
-
-          this.caps.forEach(cap => {
+      this.capTree.children.forEach((firstLevelCap) => {
+        firstLevelCap.children.forEach((secondLevelCap) => {
+          this.caps.forEach((cap) => {
             if (cap.Parent == secondLevelCap.name) {
               secondLevelCap.children.push({
                 identity: cap.ID,
@@ -136,20 +135,18 @@ export class CapabilitiesModelComponent implements OnInit {
                 description: cap.Description,
                 referenceNum: cap.ReferenceNum,
                 level: cap.Level,
-                children: []
+                children: [],
               });
             }
           });
-
         });
       });
 
       // Set Fourth-Level Children
-      this.capTree.children.forEach(firstLevelCap => {
-        firstLevelCap.children.forEach(secondLevelCap => {
-          secondLevelCap.children.forEach(thirdLevelCap => {
-
-            this.caps.forEach(cap => {
+      this.capTree.children.forEach((firstLevelCap) => {
+        firstLevelCap.children.forEach((secondLevelCap) => {
+          secondLevelCap.children.forEach((thirdLevelCap) => {
+            this.caps.forEach((cap) => {
               if (cap.Parent == thirdLevelCap.name) {
                 thirdLevelCap.children.push({
                   identity: cap.ID,
@@ -157,22 +154,20 @@ export class CapabilitiesModelComponent implements OnInit {
                   description: cap.Description,
                   referenceNum: cap.ReferenceNum,
                   level: cap.Level,
-                  children: []
+                  children: [],
                 });
               }
             });
-
           });
         });
       });
 
       // Set Fifth-Level Children
-      this.capTree.children.forEach(firstLevelCap => {
-        firstLevelCap.children.forEach(secondLevelCap => {
-          secondLevelCap.children.forEach(thirdLevelCap => {
-            thirdLevelCap.children.forEach(fourthLevelCap => {
-
-              this.caps.forEach(cap => {
+      this.capTree.children.forEach((firstLevelCap) => {
+        firstLevelCap.children.forEach((secondLevelCap) => {
+          secondLevelCap.children.forEach((thirdLevelCap) => {
+            thirdLevelCap.children.forEach((fourthLevelCap) => {
+              this.caps.forEach((cap) => {
                 if (cap.Parent == fourthLevelCap.name) {
                   fourthLevelCap.children.push({
                     identity: cap.ID,
@@ -180,12 +175,11 @@ export class CapabilitiesModelComponent implements OnInit {
                     description: cap.Description,
                     referenceNum: cap.ReferenceNum,
                     level: cap.Level,
-                    children: []
+                    children: [],
                   });
                 }
               });
             });
-
           });
         });
       });
@@ -210,17 +204,23 @@ export class CapabilitiesModelComponent implements OnInit {
     this.treemap = d3.tree().size([height, width]);
 
     // Set SVG container
-    this.vis = d3.select(element).append("svg")
-      .attr("width", width + margin.right + margin.left)
-      .attr("height", height + margin.top + margin.bottom)
-      .append("g")
-      .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+    this.vis = d3
+      .select(element)
+      .append('svg')
+      .attr('width', width + margin.right + margin.left)
+      .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
     // Set root with hierarchy tree
-    this.root = d3.hierarchy(this.capTree, function (d) { return d.children; });
+    this.root = d3.hierarchy(this.capTree, function (d) {
+      return d.children;
+    });
     this.root.x0 = height / 2;
     this.root.y0 = 0;
-    this.root.descendants().forEach((d, i) => { d.id = i; });  // Set ids for each node
+    this.root.descendants().forEach((d, i) => {
+      d.id = i;
+    }); // Set ids for each node
 
     // Sort Nodes
     this.root.sort(function (a, b) {
@@ -231,8 +231,7 @@ export class CapabilitiesModelComponent implements OnInit {
     // Only show first level children and render
     this.root.children.forEach(this.collapse);
     this.update(this.root);
-
-  }  // End of createGraph
+  } // End of createGraph
 
   // Toggle children
   private toggle(d) {
@@ -248,11 +247,11 @@ export class CapabilitiesModelComponent implements OnInit {
   // Collapse the node and all it's children
   private collapse = (d) => {
     if (d.children) {
-      d._children = d.children
-      d._children.forEach(this.collapse)
-      d.children = null
+      d._children = d.children;
+      d._children.forEach(this.collapse);
+      d.children = null;
     }
-  }
+  };
 
   private update = (source) => {
     // Transition timing in milliseconds
@@ -267,196 +266,241 @@ export class CapabilitiesModelComponent implements OnInit {
 
     // Normalize for fixed-depth.
     //// Change static number to expand or contract graph
-    nodes.forEach(function (d) { d.y = d.depth * 280 });
+    nodes.forEach(function (d) {
+      d.y = d.depth * 280;
+    });
 
     // ****************** Nodes section ***************************
 
     // Update the nodes
-    var node = this.vis.selectAll('g.node')
-      .data(nodes, function (d) { return d.id });
+    var node = this.vis.selectAll('g.node').data(nodes, function (d) {
+      return d.id;
+    });
 
     // Enter any new nodes at the parent's previous position.
-    var nodeEnter = node.enter().append('g')
-      .attr("class", "node")
-      .attr("transform", function () {
-        return "translate(" + source.y0 + "," + source.x0 + ")";
+    var nodeEnter = node
+      .enter()
+      .append('g')
+      .attr('class', 'node')
+      .attr('transform', function () {
+        return 'translate(' + source.y0 + ',' + source.x0 + ')';
       })
 
       // Toggle children on click and re-render
-      .on("click", function (d) {
-        // console.log("Clicked Node: ", d);  // Debug
-        this.toggle(d);
-        this.update(d);
-      }.bind(this));
+      .on(
+        'click',
+        function (d) {
+          // console.log("Clicked Node: ", d);  // Debug
+          this.toggle(d);
+          this.update(d);
+        }.bind(this)
+      );
 
     // Add Circle for the nodes
-    nodeEnter.append('circle')
-      .attr("class", "node")
-      .attr("r", 1e-6)
-      .style("fill", function (d) {
-        return d._children ? "lightsteelblue" : "#fff";
+    nodeEnter
+      .append('circle')
+      .attr('class', 'node')
+      .attr('r', 1e-6)
+      .style('fill', function (d) {
+        return d._children ? 'lightsteelblue' : '#fff';
       })
-      .style("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "steelblue"
-        }
-      }.bind(this))
-      .style("stroke-width", "2.5px");
+      .style(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return 'steelblue';
+          }
+        }.bind(this)
+      )
+      .style('stroke-width', '2.5px');
 
     // Add labels for the nodes
-    nodeEnter.append('text')
+    nodeEnter
+      .append('text')
       // Adjust x coordinate when at end of tree
-      .attr("x", function (d) {
+      .attr('x', function (d) {
         return d.children || d._children ? -15 : 15;
       })
 
       // Move labels above circle
-      .attr("dy", "0.35em")
+      .attr('dy', '0.35em')
 
       // Anchor text at middle with children and at start without
-      .attr("text-anchor", function (d) {
-        return d.children || d._children ? "end" : "start";
+      .attr('text-anchor', function (d) {
+        return d.children || d._children ? 'end' : 'start';
       })
 
       // Display node name for text
-      .text(function (d) { return d.data.name; })
-      .attr("font-size", "0.75rem")
-      .attr("fill", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "black"
-        }
-      }.bind(this))
+      .text(function (d) {
+        return d.data.name;
+      })
+      .attr('font-size', '0.75rem')
+      .attr(
+        'fill',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return 'black';
+          }
+        }.bind(this)
+      )
 
       // Create white surrounding on text for easier reading over lines
-      .clone(true).lower()
-      .attr("stroke-linejoin", "round")
-      .attr("stroke-width", 3)
-      .attr("stroke", "white");
+      .clone(true)
+      .lower()
+      .attr('stroke-linejoin', 'round')
+      .attr('stroke-width', 3)
+      .attr('stroke', 'white');
 
     // UPDATE
     var nodeUpdate = nodeEnter.merge(node);
 
     // Transition to the proper position for the node
-    nodeUpdate.transition()
+    nodeUpdate
+      .transition()
       .duration(duration)
-      .attr("transform", function (d) {
-        return "translate(" + d.y + "," + d.x + ")";
+      .attr('transform', function (d) {
+        return 'translate(' + d.y + ',' + d.x + ')';
       });
 
     // Update the node attributes and style
-    nodeUpdate.select('circle.node')
-      .attr("r", 6)
-      .style("fill", function (d) {
+    nodeUpdate
+      .select('circle.node')
+      .attr('r', 6)
+      .style('fill', function (d) {
         if (d._children) {
-          return "lightsteelblue";
+          return 'lightsteelblue';
         } else {
-          return "#fff";
+          return '#fff';
         }
       })
-      .style("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "steelblue"
-        }
-      }.bind(this))
-      .attr("cursor", "pointer")
+      .style(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return 'steelblue';
+          }
+        }.bind(this)
+      )
+      .attr('cursor', 'pointer')
 
       // Show detail card on hoverover
-      .on("mouseenter", function (d) {
-        d3.select("#capDetail")
-          .style("visibility", "visible")   // Show detail card
-          .style("opacity", "1");
-        d3.select("#capName")
-          .text(d.data.name + " (" + d.data.referenceNum + ")");  // Set Name
-        d3.select("#capLevel")
-          .text(d.data.level)  // Set Capability Level
-        d3.select("#capDetailbody")
-          .text(d.data.description);  // Set Body with description
+      .on(
+        'mouseenter',
+        function (d) {
+          d3.select('#capDetail')
+            .style('visibility', 'visible') // Show detail card
+            .style('opacity', '1');
+          d3.select('#capName').text(
+            d.data.name + ' (' + d.data.referenceNum + ')'
+          ); // Set Name
+          d3.select('#capLevel').text(d.data.level); // Set Capability Level
+          d3.select('#capDetailbody').text(d.data.description); // Set Body with description
 
-        // d3.select("#busCapGraph")
-        //   .style("transform", "translateY(13%)");   // Keeping this here in case the detail pane gets larger and needs to move
+          // d3.select("#busCapGraph")
+          //   .style("transform", "translateY(13%)");   // Keeping this here in case the detail pane gets larger and needs to move
 
-        // console.log("Hovered Node: ", d);  // Debug
-        this.selectedCap = d;  // Save selected node id for links
+          // console.log("Hovered Node: ", d);  // Debug
+          this.selectedCap = d; // Save selected node id for links
 
-        // Detail Pane Controls
-        var capDetail = d3.select('#capDetailLink');
+          // Detail Pane Controls
+          var capDetail = d3.select('#capDetailLink');
 
-        // When detail link is clicked
-        capDetail.on("click", function () {
-          // Grab data for selected node
-          this.apiService.getOneCap(this.selectedCap.data.identity).subscribe((data: any[]) => {
-            var capData = data[0];
-            this.tableService.capsTableClick(capData);
-          });
-        }.bind(this));
-      }.bind(this));
+          // When detail link is clicked
+          capDetail.on(
+            'click',
+            function () {
+              // Grab data for selected node
+              this.apiService
+                .getOneCap(this.selectedCap.data.identity)
+                .subscribe((data: any[]) => {
+                  var capData = data[0];
+                  this.tableService.capsTableClick(capData);
+                });
+            }.bind(this)
+          );
+        }.bind(this)
+      );
 
     // Remove any exiting nodes
-    var nodeExit = node.exit().transition()
+    var nodeExit = node
+      .exit()
+      .transition()
       .duration(duration)
-      .attr("transform", function (d) {
-        return "translate(" + source.y + "," + source.x + ")";
+      .attr('transform', function (d) {
+        return 'translate(' + source.y + ',' + source.x + ')';
       })
       .remove();
 
     // On exit reduce the node circles size to 0
-    nodeExit.select('circle')
-      .attr("r", 1e-6);
+    nodeExit.select('circle').attr('r', 1e-6);
 
     // On exit reduce the opacity of text labels
-    nodeExit.select('text')
-      .style("fill-opacity", 1e-6);
+    nodeExit.select('text').style('fill-opacity', 1e-6);
 
     // ****************** links section ***************************
 
     // Update the links...
-    var link = this.vis.selectAll('path.link')
-      .data(links, function (d) { return d.id; });
+    var link = this.vis.selectAll('path.link').data(links, function (d) {
+      return d.id;
+    });
 
     // Enter any new links at the parent's previous position.
-    var linkEnter = link.enter().insert('path', "g")
-      .attr("class", "link")
-      .attr("d", function (d) {
-        var o = { x: source.x0, y: source.y0 }
-        return diagonal(o, o)
+    var linkEnter = link
+      .enter()
+      .insert('path', 'g')
+      .attr('class', 'link')
+      .attr('d', function (d) {
+        var o = { x: source.x0, y: source.y0 };
+        return diagonal(o, o);
       })
-      .attr("fill", "none")
-      .attr("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "#ccc"
-        }
-      }.bind(this))
-      .attr("stroke-width", "3px");
+      .attr('fill', 'none')
+      .attr(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return '#ccc';
+          }
+        }.bind(this)
+      )
+      .attr('stroke-width', '3px');
 
     // UPDATE
     var linkUpdate = linkEnter.merge(link);
 
     // Transition back to the parent element position
-    linkUpdate.transition()
-      .duration(duration)
-      .attr("d", function (d) { return diagonal(d, d.parent) })
-      .attr("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "#ccc"
-        }
-      }.bind(this));
-
-    // Remove any exiting links
-    var linkExit = link.exit().transition()
+    linkUpdate
+      .transition()
       .duration(duration)
       .attr('d', function (d) {
-        var o = { x: source.x, y: source.y }
-        return diagonal(o, o)
+        return diagonal(d, d.parent);
+      })
+      .attr(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return '#ccc';
+          }
+        }.bind(this)
+      );
+
+    // Remove any exiting links
+    var linkExit = link
+      .exit()
+      .transition()
+      .duration(duration)
+      .attr('d', function (d) {
+        var o = { x: source.x, y: source.y };
+        return diagonal(o, o);
       })
       .remove();
 
@@ -468,32 +512,30 @@ export class CapabilitiesModelComponent implements OnInit {
 
     // Creates a curved (diagonal) path from parent to the child nodes
     function diagonal(s, d) {
-
       var path = `M ${s.y} ${s.x}
                   C ${(s.y + d.y) / 2} ${s.x},
                     ${(s.y + d.y) / 2} ${d.x},
-                    ${d.y} ${d.x}`
+                    ${d.y} ${d.x}`;
 
-      return path
+      return path;
     }
 
     // When close window is clicked
     var capClose = d3.select('#capDetailClose');
-    capClose.on("click", function (d) {
-      d3.select("#capDetail")
-        .style("visibility", "hidden")
-        .style("opacity", "0");
-      d3.select("#busCapGraph").style("transform", null);
+    capClose.on('click', function (d) {
+      d3.select('#capDetail')
+        .style('visibility', 'hidden')
+        .style('opacity', '0');
+      d3.select('#busCapGraph').style('transform', null);
     });
-
-  }  // End of update
+  }; // End of update
 
   public search = (event) => {
     // Clear and reset tree between searches
     this.clearSearch();
 
     // Search when enter is pressed
-    if (event.key === "Enter") {
+    if (event.key === 'Enter') {
       // console.log("Searching: ", this.searchKey); // Debug
 
       var term = this.searchKey.toUpperCase();
@@ -511,17 +553,16 @@ export class CapabilitiesModelComponent implements OnInit {
         // console.log("Final Search Paths: ", this.finalSearchPath);  // Debug
         this.update(this.root);
       } else {
-        alert(this.searchKey + " not found!");
+        alert(this.searchKey + ' not found!');
       }
 
       function searchChildren(d) {
         d.selected = false;
-        var patt = new RegExp("\\b" + this, "i");
+        var patt = new RegExp('\\b' + this, 'i');
 
-        paths.push(d);  // We assume this path is the right one
+        paths.push(d); // We assume this path is the right one
 
         if (d.data.name.match(patt) != null) {
-
           // Avoid duplication
           if (!paths.includes(d)) {
             paths.push(d);
@@ -529,15 +570,12 @@ export class CapabilitiesModelComponent implements OnInit {
 
           d.selected = true;
         } else {
-          paths.pop()  // Drop path if it's not correct
+          paths.pop(); // Drop path if it's not correct
         }
 
-        if (d.children)
-          d.children.forEach(searchChildren, this);
-        else if (d._children)
-          d._children.forEach(searchChildren, this);
-
-      };
+        if (d.children) d.children.forEach(searchChildren, this);
+        else if (d._children) d._children.forEach(searchChildren, this);
+      }
 
       function openPaths(paths) {
         for (var index = 0; index < paths.length; index++) {
@@ -550,16 +588,18 @@ export class CapabilitiesModelComponent implements OnInit {
           }
 
           // Include parent if not already in the path
-          if (paths[index].parent.data.name != 'Manage GSA' && !paths.includes(paths[index].parent)) {
+          if (
+            paths[index].parent.data.name != 'Manage GSA' &&
+            !paths.includes(paths[index].parent)
+          ) {
             paths.push(paths[index].parent);
           }
         }
 
         return paths;
-      };
-
+      }
     }
-  }  // End of search
+  }; // End of search
 
   public clearSearch() {
     // Unselect all that were in the final search path if there was one
@@ -574,5 +614,4 @@ export class CapabilitiesModelComponent implements OnInit {
     this.root.children.forEach(this.collapse);
     this.update(this.root);
   }
-
 }

--- a/src/app/views/enterprise/capabilities/capabilities.component.ts
+++ b/src/app/views/enterprise/capabilities/capabilities.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -13,10 +14,9 @@ declare var $: any;
 @Component({
   selector: 'capabilities',
   templateUrl: './capabilities.component.html',
-  styleUrls: ['./capabilities.component.css']
+  styleUrls: ['./capabilities.component.css'],
 })
 export class CapabilitiesComponent implements OnInit {
-
   row: Object = <any>{};
   ssoTable: boolean = false;
   filterTitle: string = '';
@@ -28,145 +28,169 @@ export class CapabilitiesComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     public sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentCap.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentCap.subscribe((row) => (this.row = row));
   }
 
   // Capabilities Table Options
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'CapTable',
-    classes: "table-hover table-dark clickable-table fixed-table",
+    classes: 'table-hover table-dark clickable-table fixed-table',
     showColumns: false,
     showExport: true,
     exportFileName: 'GSA_Business_Capabilities',
-    headerStyle: "bg-royal-blue",
+    headerStyle: 'bg-royal-blue',
     pagination: true,
     search: true,
     sortName: 'ReferenceNum',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.capUrl
+    url: this.apiService.capUrl,
   });
 
   // Capabilities Table Columns
-  capColumnDefs: any[] = [{
-    field: 'ReferenceNum',
-    title: 'Ref Id',
-    sortable: true
-  }, {
-    field: 'Name',
-    title: 'Capability Name',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: true,
-    class: 'text-truncate'
-  }, {
-    field: 'Level',
-    title: 'Level',
-    sortable: true
-  }, {
-    field: 'Parent',
-    title: 'Parent',
-    sortable: true
-  }];
+  capColumnDefs: any[] = [
+    {
+      field: 'ReferenceNum',
+      title: 'Ref Id',
+      sortable: true,
+    },
+    {
+      field: 'Name',
+      title: 'Capability Name',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: true,
+      class: 'text-truncate',
+    },
+    {
+      field: 'Level',
+      title: 'Level',
+      sortable: true,
+    },
+    {
+      field: 'Parent',
+      title: 'Parent',
+      sortable: true,
+    },
+  ];
 
   // Capabilities by SSO Table Columns
-  ssoColumnDefs: any[] = [{
-    field: 'ReferenceNum',
-    title: 'Ref Id',
-    sortable: true
-  }, {
-    field: 'Name',
-    title: 'Capability Name',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: true,
-    class: 'text-truncate'
-  }, {
-    field: 'Level',
-    title: 'Level',
-    sortable: true,
-  }, {
-    field: 'ParentCap',
-    title: 'Parent',
-    sortable: true
-  }, {
-    field: 'Organizations',
-    title: 'SSO',
-    sortable: true
-  }, {
-    field: 'Applications',
-    title: 'Apps',
-    sortable: true
-  }];
+  ssoColumnDefs: any[] = [
+    {
+      field: 'ReferenceNum',
+      title: 'Ref Id',
+      sortable: true,
+    },
+    {
+      field: 'Name',
+      title: 'Capability Name',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: true,
+      class: 'text-truncate',
+    },
+    {
+      field: 'Level',
+      title: 'Level',
+      sortable: true,
+    },
+    {
+      field: 'ParentCap',
+      title: 'Parent',
+      sortable: true,
+    },
+    {
+      field: 'Organizations',
+      title: 'SSO',
+      sortable: true,
+    },
+    {
+      field: 'Applications',
+      title: 'Apps',
+      sortable: true,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
     // Set JWT when logged into GEAR Manager when returning from secureAuth
     this.sharedService.setJWTonLogIn();
 
-    $('#capTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.capColumnDefs,
-      data: [],
-    }));
+    $('#capTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.capColumnDefs,
+        data: [],
+      })
+    );
 
     // Method to handle click events on the capabilities table
     $(document).ready(
-      $('#capTable').on('click-row.bs.table', function (e, row) {
-        this.tableService.capsTableClick(row);
-      }.bind(this))
+      $('#capTable').on(
+        'click-row.bs.table',
+        function (e, row) {
+          this.tableService.capsTableClick(row);
+        }.bind(this)
+      )
     );
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailCapID = params['capID'];
       if (detailCapID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailCapID}`
+        );
         this.apiService.getOneCap(detailCapID).subscribe((data: any[]) => {
           this.tableService.capsTableClick(data[0]);
         });
-      };
+      }
     });
-  
   }
 
   // Update table, filtering by SSO
   changeCapSSO(sso: string) {
-    this.ssoTable = true;  // SSO filters are on, expose main table button
+    this.ssoTable = true; // SSO filters are on, expose main table button
 
     $('#capTable').bootstrapTable('refreshOptions', {
       columns: this.ssoColumnDefs,
       idTable: 'advSearchCapSSOTable',
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Business_Capabilities_by_SSO')
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Business_Capabilities_by_SSO'
+        ),
       },
-      url: this.apiService.capUrl + '/sso/' + sso
+      url: this.apiService.capUrl + '/sso/' + sso,
     });
 
     this.filterTitle = `${sso} `;
   }
 
   backToMainCap() {
-    this.ssoTable = false;  // Hide main button
+    this.ssoTable = false; // Hide main button
 
     $('#capTable').bootstrapTable('refreshOptions', {
       columns: this.capColumnDefs,
       idTable: 'advSearchCapTable',
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Business_Capabilities')
+        fileName: this.sharedService.fileNameFmt('GSA_Business_Capabilities'),
       },
-      url: this.apiService.capUrl
+      url: this.apiService.capUrl,
     });
 
     this.filterTitle = '';
   }
-
 }

--- a/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
+++ b/src/app/views/enterprise/organizations-chart/organizations-chart.component.ts
@@ -5,6 +5,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare D3 library
 declare var d3: any;
@@ -22,10 +23,9 @@ interface OrgTree {
 @Component({
   selector: 'organizations-chart',
   templateUrl: './organizations-chart.component.html',
-  styleUrls: ['./organizations-chart.component.css']
+  styleUrls: ['./organizations-chart.component.css'],
 })
 export class OrganizationsChartComponent implements OnInit {
-
   @ViewChild('orgChart') public graphContainer: ElementRef;
   private orgs: any[] = [];
   private root: any = {};
@@ -47,25 +47,27 @@ export class OrganizationsChartComponent implements OnInit {
     private modalService: ModalsService,
     private route: ActivatedRoute,
     private sharedService: SharedService,
-    private tableService: TableService) { }
+    private tableService: TableService,
+    private titleService: Title
+  ) {}
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
     this.getOrgData();
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailOrgID = params['orgID'];
       if (detailOrgID) {
         this.apiService.getOneOrg(detailOrgID).subscribe((data: any[]) => {
           this.tableService.orgsTableClick(data[0]);
         });
-      };
-    }); 
+      }
+    });
   }
 
   // Create Org Chart
@@ -75,101 +77,93 @@ export class OrganizationsChartComponent implements OnInit {
       this.orgs = data;
 
       // Set Root Node
-      this.orgs.forEach(org => {
+      this.orgs.forEach((org) => {
         if (org.Name == this.rootOrg) {
           this.orgTree = {
             identity: org.ID,
             name: org.Name,
             displayName: org.DisplayName,
-            children: []
-          }
-        };
+            children: [],
+          };
+        }
       });
 
       // Set First-Level Children
-      this.orgs.forEach(org => {
+      this.orgs.forEach((org) => {
         if (org.Parent == this.orgTree.name) {
           this.orgTree.children.push({
             identity: org.ID,
             name: org.Name,
             displayName: org.DisplayName,
-            children: []
+            children: [],
           });
         }
       });
 
       // Set Second-Level Children
-      this.orgTree.children.forEach(firstLevelOrg => {
-
-        this.orgs.forEach(org => {
+      this.orgTree.children.forEach((firstLevelOrg) => {
+        this.orgs.forEach((org) => {
           if (org.Parent == firstLevelOrg.name) {
             firstLevelOrg.children.push({
               identity: org.ID,
               name: org.Name,
               displayName: org.DisplayName,
-              children: []
+              children: [],
             });
           }
         });
-
       });
 
       // Set Third-Level Children
-      this.orgTree.children.forEach(firstLevelOrg => {
-        firstLevelOrg.children.forEach(secondLevelOrg => {
-
-          this.orgs.forEach(org => {
+      this.orgTree.children.forEach((firstLevelOrg) => {
+        firstLevelOrg.children.forEach((secondLevelOrg) => {
+          this.orgs.forEach((org) => {
             if (org.Parent == secondLevelOrg.name) {
               secondLevelOrg.children.push({
                 identity: org.ID,
                 name: org.Name,
                 displayName: org.DisplayName,
-                children: []
+                children: [],
               });
             }
           });
-
         });
       });
 
       // Set Fourth-Level Children
-      this.orgTree.children.forEach(firstLevelOrg => {
-        firstLevelOrg.children.forEach(secondLevelOrg => {
-          secondLevelOrg.children.forEach(thirdLevelOrg => {
-
-            this.orgs.forEach(org => {
+      this.orgTree.children.forEach((firstLevelOrg) => {
+        firstLevelOrg.children.forEach((secondLevelOrg) => {
+          secondLevelOrg.children.forEach((thirdLevelOrg) => {
+            this.orgs.forEach((org) => {
               if (org.Parent == thirdLevelOrg.name) {
                 thirdLevelOrg.children.push({
                   identity: org.ID,
                   name: org.Name,
                   displayName: org.DisplayName,
-                  children: []
+                  children: [],
                 });
               }
             });
-
           });
         });
       });
 
       // Set Fifth-Level Children
-      this.orgTree.children.forEach(firstLevelOrg => {
-        firstLevelOrg.children.forEach(secondLevelOrg => {
-          secondLevelOrg.children.forEach(thirdLevelOrg => {
-            thirdLevelOrg.children.forEach(fourthLevelOrg => {
-
-              this.orgs.forEach(org => {
+      this.orgTree.children.forEach((firstLevelOrg) => {
+        firstLevelOrg.children.forEach((secondLevelOrg) => {
+          secondLevelOrg.children.forEach((thirdLevelOrg) => {
+            thirdLevelOrg.children.forEach((fourthLevelOrg) => {
+              this.orgs.forEach((org) => {
                 if (org.Parent == fourthLevelOrg.name) {
                   fourthLevelOrg.children.push({
                     identity: org.ID,
                     name: org.Name,
                     displayName: org.DisplayName,
-                    children: []
+                    children: [],
                   });
                 }
               });
             });
-
           });
         });
       });
@@ -194,29 +188,36 @@ export class OrganizationsChartComponent implements OnInit {
     this.treemap = d3.tree().size([height, width]);
 
     // Set SVG container
-    this.vis = d3.select(element).append("svg")
-      .attr("width", width + margin.right + margin.left)
-      .attr("height", height + margin.top + margin.bottom)
-      .append("g")
-      .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+    this.vis = d3
+      .select(element)
+      .append('svg')
+      .attr('width', width + margin.right + margin.left)
+      .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
     // Set root with hierarchy tree
-    this.root = d3.hierarchy(this.orgTree, function (d) { return d.children; });
+    this.root = d3.hierarchy(this.orgTree, function (d) {
+      return d.children;
+    });
     this.root.x0 = height / 2;
     this.root.y0 = 0;
-    this.root.descendants().forEach((d, i) => { d.id = i; });  // Set ids for each node
+    this.root.descendants().forEach((d, i) => {
+      d.id = i;
+    }); // Set ids for each node
 
     // Sort Nodes
     this.root.sort(function (a, b) {
-      return a.data.displayName.toLowerCase().localeCompare(b.data.displayName.toLowerCase());
+      return a.data.displayName
+        .toLowerCase()
+        .localeCompare(b.data.displayName.toLowerCase());
     });
     // console.log("Root: ", this.root);  // Debug
 
     // Only show first level children and render
     this.root.children.forEach(this.collapse);
     this.update(this.root);
-
-  }  // End of createGraph
+  } // End of createGraph
 
   // Toggle children
   private toggle(d) {
@@ -232,11 +233,11 @@ export class OrganizationsChartComponent implements OnInit {
   // Collapse the node and all it's children
   private collapse = (d) => {
     if (d.children) {
-      d._children = d.children
-      d._children.forEach(this.collapse)
-      d.children = null
+      d._children = d.children;
+      d._children.forEach(this.collapse);
+      d.children = null;
     }
-  }
+  };
 
   private update = (source) => {
     // Transition timing in milliseconds
@@ -251,195 +252,240 @@ export class OrganizationsChartComponent implements OnInit {
 
     // Normalize for fixed-depth.
     //// Change static number to expand or contract graph
-    nodes.forEach(function (d) { d.y = d.depth * 280 });
+    nodes.forEach(function (d) {
+      d.y = d.depth * 280;
+    });
 
     // ****************** Nodes section ***************************
 
     // Update the nodes
-    var node = this.vis.selectAll('g.node')
-      .data(nodes, function (d) { return d.id });
+    var node = this.vis.selectAll('g.node').data(nodes, function (d) {
+      return d.id;
+    });
 
     // Enter any new nodes at the parent's previous position.
-    var nodeEnter = node.enter().append('g')
-      .attr("class", "node")
-      .attr("transform", function () {
-        return "translate(" + source.y0 + "," + source.x0 + ")";
+    var nodeEnter = node
+      .enter()
+      .append('g')
+      .attr('class', 'node')
+      .attr('transform', function () {
+        return 'translate(' + source.y0 + ',' + source.x0 + ')';
       })
 
       // Toggle children on click and re-render
-      .on("click", function (d) {
-        // console.log("Clicked Node: ", d);  // Debug
-        this.toggle(d);
-        this.update(d);
-      }.bind(this));
+      .on(
+        'click',
+        function (d) {
+          // console.log("Clicked Node: ", d);  // Debug
+          this.toggle(d);
+          this.update(d);
+        }.bind(this)
+      );
 
     // Add Circle for the nodes
-    nodeEnter.append('circle')
-      .attr("class", "node")
-      .attr("r", 1e-6)
-      .style("fill", function (d) {
-        return d._children ? "lightsteelblue" : "#fff";
+    nodeEnter
+      .append('circle')
+      .attr('class', 'node')
+      .attr('r', 1e-6)
+      .style('fill', function (d) {
+        return d._children ? 'lightsteelblue' : '#fff';
       })
-      .style("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "steelblue"
-        }
-      }.bind(this))
-      .style("stroke-width", "2.5px");
+      .style(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return 'steelblue';
+          }
+        }.bind(this)
+      )
+      .style('stroke-width', '2.5px');
 
     // Add labels for the nodes
-    nodeEnter.append('text')
+    nodeEnter
+      .append('text')
       // Adjust x coordinate when at end of tree
-      .attr("x", function (d) {
+      .attr('x', function (d) {
         return d.children || d._children ? -15 : 15;
       })
 
       // Move labels above circle
-      .attr("dy", "0.35em")
+      .attr('dy', '0.35em')
 
       // Anchor text at middle with children and at start without
-      .attr("text-anchor", function (d) {
-        return d.children || d._children ? "end" : "start";
+      .attr('text-anchor', function (d) {
+        return d.children || d._children ? 'end' : 'start';
       })
 
       // Display node name for text
-      .text(function (d) { return d.data.displayName; })
-      .attr("font-size", "0.75rem")
-      .attr("fill", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "black"
-        }
-      }.bind(this))
+      .text(function (d) {
+        return d.data.displayName;
+      })
+      .attr('font-size', '0.75rem')
+      .attr(
+        'fill',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return 'black';
+          }
+        }.bind(this)
+      )
 
       // Create white surrounding on text for easier reading over lines
-      .clone(true).lower()
-      .attr("stroke-linejoin", "round")
-      .attr("stroke-width", 3)
-      .attr("stroke", "white");
+      .clone(true)
+      .lower()
+      .attr('stroke-linejoin', 'round')
+      .attr('stroke-width', 3)
+      .attr('stroke', 'white');
 
     // UPDATE
     var nodeUpdate = nodeEnter.merge(node);
 
     // Transition to the proper position for the node
-    nodeUpdate.transition()
+    nodeUpdate
+      .transition()
       .duration(duration)
-      .attr("transform", function (d) {
-        return "translate(" + d.y + "," + d.x + ")";
+      .attr('transform', function (d) {
+        return 'translate(' + d.y + ',' + d.x + ')';
       });
 
     // Update the node attributes and style
-    nodeUpdate.select('circle.node')
-      .attr("r", 6)
-      .style("fill", function (d) {
+    nodeUpdate
+      .select('circle.node')
+      .attr('r', 6)
+      .style('fill', function (d) {
         if (d._children) {
-          return "lightsteelblue";
+          return 'lightsteelblue';
         } else {
-          return "#fff";
+          return '#fff';
         }
       })
-      .style("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "steelblue"
-        }
-      }.bind(this))
-      .attr("cursor", "pointer")
+      .style(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return 'steelblue';
+          }
+        }.bind(this)
+      )
+      .attr('cursor', 'pointer')
 
       // Show detail card on hoverover
-      .on("mouseenter", function (d) {
-        d3.select("#orgDetail")
-        .style("visibility", "visible")   // Show detail card
-        .style("opacity", "1");
+      .on(
+        'mouseenter',
+        function (d) {
+          d3.select('#orgDetail')
+            .style('visibility', 'visible') // Show detail card
+            .style('opacity', '1');
 
-        d3.select("#orgName")
-          .text(d.data.name);  // Set Name
+          d3.select('#orgName').text(d.data.name); // Set Name
 
-        // d3.select("#orgChart")
-        //   .style("transform", "translateY(13%)");   // Keeping this here in case the detail pane gets larger and needs to move
+          // d3.select("#orgChart")
+          //   .style("transform", "translateY(13%)");   // Keeping this here in case the detail pane gets larger and needs to move
 
-        // console.log("Hovered Node: ", d);  // Debug
-        this.selectedOrg = d;  // Save selected node for links
+          // console.log("Hovered Node: ", d);  // Debug
+          this.selectedOrg = d; // Save selected node for links
 
-        // Detail Pane Controls
-        var orgDetail = d3.select('#orgDetailLink');
+          // Detail Pane Controls
+          var orgDetail = d3.select('#orgDetailLink');
 
-        // When detail link is clicked
-        orgDetail.on("click", function () {
-          // console.log("Selected Node: ", this.selectedOrg);  // Debug
+          // When detail link is clicked
+          orgDetail.on(
+            'click',
+            function () {
+              // console.log("Selected Node: ", this.selectedOrg);  // Debug
 
-          // Grab data for selected node
-          this.apiService.getOneOrg(this.selectedOrg.data.identity).subscribe((data: any[]) => {
-            var orgData = data[0];
-            this.tableService.orgsTableClick(orgData);
-          });
-        }.bind(this));
-      }.bind(this));
+              // Grab data for selected node
+              this.apiService
+                .getOneOrg(this.selectedOrg.data.identity)
+                .subscribe((data: any[]) => {
+                  var orgData = data[0];
+                  this.tableService.orgsTableClick(orgData);
+                });
+            }.bind(this)
+          );
+        }.bind(this)
+      );
 
     // Remove any exiting nodes
-    var nodeExit = node.exit().transition()
+    var nodeExit = node
+      .exit()
+      .transition()
       .duration(duration)
-      .attr("transform", function (d) {
-        return "translate(" + source.y + "," + source.x + ")";
+      .attr('transform', function (d) {
+        return 'translate(' + source.y + ',' + source.x + ')';
       })
       .remove();
 
     // On exit reduce the node circles size to 0
-    nodeExit.select('circle')
-      .attr("r", 1e-6);
+    nodeExit.select('circle').attr('r', 1e-6);
 
     // On exit reduce the opacity of text labels
-    nodeExit.select('text')
-      .style("fill-opacity", 1e-6);
+    nodeExit.select('text').style('fill-opacity', 1e-6);
 
     // ****************** links section ***************************
 
     // Update the links...
-    var link = this.vis.selectAll('path.link')
-      .data(links, function (d) { return d.id; });
+    var link = this.vis.selectAll('path.link').data(links, function (d) {
+      return d.id;
+    });
 
     // Enter any new links at the parent's previous position.
-    var linkEnter = link.enter().insert('path', "g")
-      .attr("class", "link")
-      .attr("d", function (d) {
-        var o = { x: source.x0, y: source.y0 }
-        return diagonal(o, o)
+    var linkEnter = link
+      .enter()
+      .insert('path', 'g')
+      .attr('class', 'link')
+      .attr('d', function (d) {
+        var o = { x: source.x0, y: source.y0 };
+        return diagonal(o, o);
       })
-      .attr("fill", "none")
-      .attr("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "#ccc"
-        }
-      }.bind(this))
-      .attr("stroke-width", "3px");
+      .attr('fill', 'none')
+      .attr(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return '#ccc';
+          }
+        }.bind(this)
+      )
+      .attr('stroke-width', '3px');
 
     // UPDATE
     var linkUpdate = linkEnter.merge(link);
 
     // Transition back to the parent element position
-    linkUpdate.transition()
-      .duration(duration)
-      .attr("d", function (d) { return diagonal(d, d.parent) })
-      .attr("stroke", function (d) {
-        if (d.selected) {
-          return this.highlightColor;
-        } else {
-          return "#ccc"
-        }
-      }.bind(this));
-
-    // Remove any exiting links
-    var linkExit = link.exit().transition()
+    linkUpdate
+      .transition()
       .duration(duration)
       .attr('d', function (d) {
-        var o = { x: source.x, y: source.y }
-        return diagonal(o, o)
+        return diagonal(d, d.parent);
+      })
+      .attr(
+        'stroke',
+        function (d) {
+          if (d.selected) {
+            return this.highlightColor;
+          } else {
+            return '#ccc';
+          }
+        }.bind(this)
+      );
+
+    // Remove any exiting links
+    var linkExit = link
+      .exit()
+      .transition()
+      .duration(duration)
+      .attr('d', function (d) {
+        var o = { x: source.x, y: source.y };
+        return diagonal(o, o);
       })
       .remove();
 
@@ -451,32 +497,30 @@ export class OrganizationsChartComponent implements OnInit {
 
     // Creates a curved (diagonal) path from parent to the child nodes
     function diagonal(s, d) {
-
       var path = `M ${s.y} ${s.x}
                   C ${(s.y + d.y) / 2} ${s.x},
                     ${(s.y + d.y) / 2} ${d.x},
-                    ${d.y} ${d.x}`
+                    ${d.y} ${d.x}`;
 
-      return path
+      return path;
     }
 
     // When close window is clicked
     var orgClose = d3.select('#orgDetailClose');
-    orgClose.on("click", function (d) {
-      d3.select("#orgDetail")
-        .style("visibility", "hidden")
-        .style("opacity", "0");
-      d3.select("#orgChart").style("transform", null);
+    orgClose.on('click', function (d) {
+      d3.select('#orgDetail')
+        .style('visibility', 'hidden')
+        .style('opacity', '0');
+      d3.select('#orgChart').style('transform', null);
     });
-
-  }  // End of update
+  }; // End of update
 
   public search = (event) => {
     // Clear and reset tree between searches
     this.clearSearch();
 
     // Search when enter is pressed
-    if (event.key === "Enter") {
+    if (event.key === 'Enter') {
       // console.log("Searching: ", this.searchKey); // Debug
 
       var term = this.searchKey.toUpperCase();
@@ -494,17 +538,19 @@ export class OrganizationsChartComponent implements OnInit {
         // console.log("Final Search Paths: ", this.finalSearchPath);  // Debug
         this.update(this.root);
       } else {
-        alert(this.searchKey + " not found!");
+        alert(this.searchKey + ' not found!');
       }
 
       function searchChildren(d) {
         d.selected = false;
-        var patt = new RegExp("\\b" + this, "i");
+        var patt = new RegExp('\\b' + this, 'i');
 
-        paths.push(d);  // We assume this path is the right one
+        paths.push(d); // We assume this path is the right one
 
-        if (d.data.name.match(patt) != null || d.data.displayName.match(patt) != null) {
-
+        if (
+          d.data.name.match(patt) != null ||
+          d.data.displayName.match(patt) != null
+        ) {
           // Avoid duplication
           if (!paths.includes(d)) {
             paths.push(d);
@@ -512,15 +558,12 @@ export class OrganizationsChartComponent implements OnInit {
 
           d.selected = true;
         } else {
-          paths.pop()  // Drop path if it's not correct
+          paths.pop(); // Drop path if it's not correct
         }
 
-        if (d.children)
-          d.children.forEach(searchChildren, this);
-        else if (d._children)
-          d._children.forEach(searchChildren, this);
-
-      };
+        if (d.children) d.children.forEach(searchChildren, this);
+        else if (d._children) d._children.forEach(searchChildren, this);
+      }
 
       function openPaths(paths) {
         for (var index = 0; index < paths.length; index++) {
@@ -533,16 +576,18 @@ export class OrganizationsChartComponent implements OnInit {
           }
 
           // Include parent if not already in the path
-          if (paths[index].parent.data.displayName != 'Administrator (A)' && !paths.includes(paths[index].parent)) {
+          if (
+            paths[index].parent.data.displayName != 'Administrator (A)' &&
+            !paths.includes(paths[index].parent)
+          ) {
             paths.push(paths[index].parent);
           }
         }
 
         return paths;
-      };
-
+      }
     }
-  }  // End of search
+  }; // End of search
 
   public clearSearch() {
     // Unselect all that were in the final search path if there was one
@@ -557,5 +602,4 @@ export class OrganizationsChartComponent implements OnInit {
     this.root.children.forEach(this.collapse);
     this.update(this.root);
   }
-
 }

--- a/src/app/views/enterprise/organizations/organizations.component.ts
+++ b/src/app/views/enterprise/organizations/organizations.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -13,10 +14,9 @@ declare var $: any;
 @Component({
   selector: 'organizations',
   templateUrl: './organizations.component.html',
-  styleUrls: ['./organizations.component.css']
+  styleUrls: ['./organizations.component.css'],
 })
 export class OrganizationsComponent implements OnInit {
-
   row: Object = <any>{};
 
   constructor(
@@ -26,78 +26,92 @@ export class OrganizationsComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentInvest.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentInvest.subscribe((row) => (this.row = row));
   }
 
   // Organizations Table Options
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'OrgTable',
-    classes: "table-hover table-dark clickable-table",
+    classes: 'table-hover table-dark clickable-table',
     showColumns: false,
     showExport: true,
     exportFileName: 'GSA_Organizations',
-    headerStyle: "bg-royal-blue",
+    headerStyle: 'bg-royal-blue',
     pagination: true,
     search: true,
     sortName: 'OrgSymbol',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.orgUrl
+    url: this.apiService.orgUrl,
   });
 
   // Organizations Table Columns
-  columnDefs: any[] = [{
-    field: 'OrgSymbol',
-    title: 'Org Symbol',
-    sortable: true
-  }, {
-    field: 'Name',
-    title: 'Organization Name',
-    sortable: true
-  }, {
-    field: 'SSOName',
-    title: 'SSO Name',
-    sortable: true
-  }, {
-    field: 'TwoLetterOrgSymbol',
-    title: 'Two Letter Org',
-    sortable: true
-  }, {
-    field: 'TwoLetterOrgName',
-    title: 'Two Letter Org Name',
-    sortable: true
-  }];
+  columnDefs: any[] = [
+    {
+      field: 'OrgSymbol',
+      title: 'Org Symbol',
+      sortable: true,
+    },
+    {
+      field: 'Name',
+      title: 'Organization Name',
+      sortable: true,
+    },
+    {
+      field: 'SSOName',
+      title: 'SSO Name',
+      sortable: true,
+    },
+    {
+      field: 'TwoLetterOrgSymbol',
+      title: 'Two Letter Org',
+      sortable: true,
+    },
+    {
+      field: 'TwoLetterOrgName',
+      title: 'Two Letter Org Name',
+      sortable: true,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
-    $('#orgTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.columnDefs,
-      data: [],
-    }));
+    $('#orgTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.columnDefs,
+        data: [],
+      })
+    );
 
     // Method to handle click events on the organization table
     $(document).ready(
-      $('#orgTable').on('click-row.bs.table', function (e, row) {
-        this.tableService.orgsTableClick(row);
-      }.bind(this)
-      ));
+      $('#orgTable').on(
+        'click-row.bs.table',
+        function (e, row) {
+          this.tableService.orgsTableClick(row);
+        }.bind(this)
+      )
+    );
 
-      // Method to open details modal when referenced directly via URL
-      this.route.params.subscribe(params => {
-        var detailOrgID = params['orgID'];
-        if (detailOrgID) {
-          this.apiService.getOneOrg(detailOrgID).subscribe((data: any[]) => {
-            this.tableService.orgsTableClick(data[0]);
-          });
-        };
-      });  
-
+    // Method to open details modal when referenced directly via URL
+    this.route.params.subscribe((params) => {
+      var detailOrgID = params['orgID'];
+      if (detailOrgID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailOrgID}`
+        );
+        this.apiService.getOneOrg(detailOrgID).subscribe((data: any[]) => {
+          this.tableService.orgsTableClick(data[0]);
+        });
+      }
+    });
   }
-
 }

--- a/src/app/views/enterprise/serviceCategory/serviceCategory.component.ts
+++ b/src/app/views/enterprise/serviceCategory/serviceCategory.component.ts
@@ -94,10 +94,10 @@ export class ServiceCategoryComponent implements OnInit {
     // Method to open details modal when referenced directly via URL
     this.route.params.subscribe((params) => {
       var detailServiceCategoryID = params['serviceCategoryID'];
-      this.titleService.setTitle(
-        `${this.titleService.getTitle()} - ${detailServiceCategoryID}`
-      );
       if (detailServiceCategoryID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailServiceCategoryID}`
+        );
         this.apiService
           .getOneServiceCategory(detailServiceCategoryID)
           .subscribe((data: any[]) => {

--- a/src/app/views/enterprise/serviceCategory/serviceCategory.component.ts
+++ b/src/app/views/enterprise/serviceCategory/serviceCategory.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -25,7 +26,8 @@ export class ServiceCategoryComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private sharedService: SharedService,
-    private tableService: TableService
+    private tableService: TableService,
+    private titleService: Title
   ) {
     this.modalService.currentInvest.subscribe((row) => (this.row = row));
   }
@@ -92,6 +94,9 @@ export class ServiceCategoryComponent implements OnInit {
     // Method to open details modal when referenced directly via URL
     this.route.params.subscribe((params) => {
       var detailServiceCategoryID = params['serviceCategoryID'];
+      this.titleService.setTitle(
+        `${this.titleService.getTitle()} - ${detailServiceCategoryID}`
+      );
       if (detailServiceCategoryID) {
         this.apiService
           .getOneServiceCategory(detailServiceCategoryID)

--- a/src/app/views/main/home/home.component.html
+++ b/src/app/views/main/home/home.component.html
@@ -9,53 +9,62 @@
     <div class="card-deck mb-3 text-center">
       <div class="card mb-4 shadow">
         <div class="card-header bg-info">
-          <h4 class="my-0 font-weight-normal">What is GEAR?</h4>
+          <h4 class="my-0 font-weight-normal text-white">What is GEAR?</h4>
         </div>
         <div class="card-body d-flex">
-          <p class="align-self-center">
-            GSA EA Analytics and Reporting (GEAR) is a tool to provide commonly used strategic, business, and technical
-            information to users throughout GSA in order to provide insight into the common direction for GSA IT and to
-            provide working groups with data that they need to do their jobs.
+          <p>
+            GSA EA Analytics and Reporting (GEAR) is a tool to provide commonly
+            used strategic, business, and technical information to users
+            throughout GSA in order to provide insight into the common direction
+            for GSA IT and to provide working groups with data that they need to
+            do their jobs.
           </p>
         </div>
       </div>
       <div class="card mb-4 shadow">
         <div class="card-header bg-info">
-          <h4 class="my-0 font-weight-normal">Who Can Use GEAR?</h4>
+          <h4 class="my-0 font-weight-normal text-white">Who Can Use GEAR?</h4>
         </div>
         <div class="card-body d-flex">
-          <p class="align-self-center"> Anyone logged on to the GSA network can access and download data from GEAR.
-            Any data discrepencies should be addressed with the data owners themselves to update the respective data
-            sources.
-            <br><br>
-            The "Contact/Feedback" dropdown menu in the top right corner of the page can be used regarding IT Standards
-            or any other issues or questions with GEAR itself.
+          <p>
+            Anyone logged on to the GSA network can access and download data
+            from GEAR. Any data discrepencies should be addressed with the data
+            owners themselves to update the respective data sources.
+            <br /><br />
+            The "Contact/Feedback" dropdown menu in the top right corner of the
+            page can be used regarding IT Standards or any other issues or
+            questions with GEAR itself.
           </p>
         </div>
       </div>
       <div class="card mb-4 shadow">
         <div class="card-header bg-info">
-          <h4 class="my-0 font-weight-normal">How Do I Use GEAR?</h4>
+          <h4 class="my-0 font-weight-normal text-white">How Do I Use GEAR?</h4>
         </div>
         <div class="card-body d-flex">
-          <p class="align-self-center">By clicking on the tabs on the left (or the expansion button on the top left to
-            expand the tabs), you can explore the various investments, applications, FISMA systems, and technology
-            standards used in GSA. Each section will have a <i class="far fa-question-circle"></i> icon for more
-            information on how to use that table.
-            <br><br>
-            On the top of the page is a global search field for any item in GEAR. Enter your search term into the field
-            and press "Enter" on your keyboard icon to execute. With any <b>search field</b> on GEAR, you can press
-            "Enter" on your keyboard to execute the search.
+          <p>
+            By clicking on the tabs on the left (or the expansion button on the
+            top left to expand the tabs), you can explore the various
+            investments, applications, FISMA systems, and technology standards
+            used in GSA. Each section will have a
+            <i class="far fa-question-circle"></i> icon for more information on
+            how to use that table. <br /><br />
+            On the top of the page is a global search field for any item in
+            GEAR. Enter your search term into the field and press "Enter" on
+            your keyboard icon to execute. With any <b>search field</b> on GEAR,
+            you can press "Enter" on your keyboard to execute the search.
           </p>
         </div>
       </div>
     </div>
-
   </div>
   <!-- End of Cards -->
 
   <div class="row">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/8/89/US-GeneralServicesAdministration-Logo.svg"
-      alt="GSA Logo" class="mx-auto">
+    <img
+      src="https://upload.wikimedia.org/wikipedia/commons/8/89/US-GeneralServicesAdministration-Logo.svg"
+      alt="GSA Logo"
+      class="mx-auto"
+    />
   </div>
 </div>

--- a/src/app/views/security/fisma-pocs/fisma-pocs.component.ts
+++ b/src/app/views/security/fisma-pocs/fisma-pocs.component.ts
@@ -5,6 +5,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -12,10 +13,9 @@ declare var $: any;
 @Component({
   selector: 'fisma-pocs',
   templateUrl: './fisma-pocs.component.html',
-  styleUrls: ['./fisma-pocs.component.css']
+  styleUrls: ['./fisma-pocs.component.css'],
 })
 export class FismaPocsComponent implements OnInit {
-
   row: Object = <any>{};
 
   constructor(
@@ -23,104 +23,124 @@ export class FismaPocsComponent implements OnInit {
     private modalService: ModalsService,
     private route: ActivatedRoute,
     private sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentFismaSys.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentFismaSys.subscribe((row) => (this.row = row));
   }
 
   // FISMA POC Table Options
   pocTableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'FismaPOCTable',
-    classes: "table-hover table-dark clickable-table",
+    classes: 'table-hover table-dark clickable-table',
     showColumns: true,
     showExport: true,
     exportFileName: 'GSA_FISMA_POCs',
-    headerStyle: "bg-warning",
+    headerStyle: 'bg-warning',
     pagination: true,
     search: true,
     sortName: 'Name',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.fismaUrl
+    url: this.apiService.fismaUrl,
   });
 
   // FISMA POC Table Columns
-  pocColumnDefs: any[] = [{
-    field: 'Name',
-    title: 'System Name',
-    sortable: true
-  }, {
-    field: 'FIPS_Impact_Level',
-    title: 'FIPS Impact Level',
-    sortable: true
-  }, {
-    field: 'Authorizing Official',
-    title: 'Authorizing Official',
-    sortable: true,
-    formatter: this.pocFormatter
-  }, {
-    field: 'System Owner',
-    title: 'System Owner',
-    sortable: true,
-    formatter: this.pocFormatter
-  }, {
-    field: 'ISSM',
-    title: 'ISSM',
-    sortable: true,
-    formatter: this.pocFormatter
-  }, {
-    field: 'ISSO',
-    title: 'ISSO',
-    sortable: true,
-    formatter: this.pocFormatter
-  }, {
-    field: 'RespOrg',
-    title: 'Responsible Org',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'BusOrg',
-    title: 'Business Org',
-    sortable: true,
-    visible: false
-  }];
+  pocColumnDefs: any[] = [
+    {
+      field: 'Name',
+      title: 'System Name',
+      sortable: true,
+    },
+    {
+      field: 'FIPS_Impact_Level',
+      title: 'FIPS Impact Level',
+      sortable: true,
+    },
+    {
+      field: 'Authorizing Official',
+      title: 'Authorizing Official',
+      sortable: true,
+      formatter: this.pocFormatter,
+    },
+    {
+      field: 'System Owner',
+      title: 'System Owner',
+      sortable: true,
+      formatter: this.pocFormatter,
+    },
+    {
+      field: 'ISSM',
+      title: 'ISSM',
+      sortable: true,
+      formatter: this.pocFormatter,
+    },
+    {
+      field: 'ISSO',
+      title: 'ISSO',
+      sortable: true,
+      formatter: this.pocFormatter,
+    },
+    {
+      field: 'RespOrg',
+      title: 'Responsible Org',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'BusOrg',
+      title: 'Business Org',
+      sortable: true,
+      visible: false,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
-    $('#fismaPOCTable').bootstrapTable($.extend(this.pocTableOptions, {
-      columns: this.pocColumnDefs,
-      data: [],
-    }));
+    $('#fismaPOCTable').bootstrapTable(
+      $.extend(this.pocTableOptions, {
+        columns: this.pocColumnDefs,
+        data: [],
+      })
+    );
 
     // Filter out "Pending" Status
     $(document).ready(
       $('#fismaPOCTable').bootstrapTable('filterBy', {
         Status: 'Active',
-		SystemLevel: 'System'
+        SystemLevel: 'System',
       })
     );
 
     // Method to handle click events on the FISMA POC table
     $(document).ready(
-      $('#fismaPOCTable').on('dbl-click-row.bs.table', function (e, row) {
-        this.tableService.fismaTableClick(row);
-      }.bind(this)
-      ));
+      $('#fismaPOCTable').on(
+        'dbl-click-row.bs.table',
+        function (e, row) {
+          this.tableService.fismaTableClick(row);
+        }.bind(this)
+      )
+    );
 
-      // Method to open details modal when referenced directly via URL
-      this.route.params.subscribe(params => {
-        var detailFismaID = params['fismaID'];
-        if (detailFismaID) {
-          this.apiService.getOneFISMASys(detailFismaID).subscribe((data: any[]) => {
+    // Method to open details modal when referenced directly via URL
+    this.route.params.subscribe((params) => {
+      var detailFismaID = params['fismaID'];
+      if (detailFismaID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailFismaID}`
+        );
+        this.apiService
+          .getOneFISMASys(detailFismaID)
+          .subscribe((data: any[]) => {
             this.tableService.fismaTableClick(data[0]);
           });
-        };
-      }); 
-
+      }
+    });
   }
 
   pocFormatter(value, row, index, field) {
@@ -142,7 +162,7 @@ export class FismaPocsComponent implements OnInit {
         // Only continue for POC type matching the desired field
         if (poctype[0] === field) {
           poc = poctype[1].split('; ');
-          
+
           // Return if there are no POCs in this field
           if (poc[0] === '') {
             return 'None Provided';
@@ -167,14 +187,18 @@ export class FismaPocsComponent implements OnInit {
                 // Format email into a HTML link
                 if (tmpObj.email) {
                   linkStr += `<a href="https://mail.google.com/mail/?view=cm&fs=1&to=${tmpObj.email}"
-                    target="_blank" rel="noopener">${tmpObj.email}</a><br>`
+                    target="_blank" rel="noopener">${tmpObj.email}</a><br>`;
                 }
 
                 // Format number into phone format
                 if (tmpObj.phone) {
-                  linkStr += tmpObj.phone.substring(0, 4) + '-' +
-                    tmpObj.phone.substring(4, 7) + '-' +
-                    tmpObj.phone.substring(7, 11) + '<br>'
+                  linkStr +=
+                    tmpObj.phone.substring(0, 4) +
+                    '-' +
+                    tmpObj.phone.substring(4, 7) +
+                    '-' +
+                    tmpObj.phone.substring(7, 11) +
+                    '<br>';
                 }
 
                 pocs.push(linkStr);
@@ -188,7 +212,5 @@ export class FismaPocsComponent implements OnInit {
     } else {
       return 'None Provided';
     }
-
   }
-
 }

--- a/src/app/views/security/fisma/fisma.component.ts
+++ b/src/app/views/security/fisma/fisma.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -13,10 +14,9 @@ declare var $: any;
 @Component({
   selector: 'fisma',
   templateUrl: './fisma.component.html',
-  styleUrls: ['./fisma.component.css']
+  styleUrls: ['./fisma.component.css'],
 })
 export class FismaComponent implements OnInit {
-
   row: Object = <any>{};
   retiredTable: boolean = false;
 
@@ -27,186 +27,211 @@ export class FismaComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentFismaSys.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentFismaSys.subscribe((row) => (this.row = row));
   }
 
   // FISMA System Table Options
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'FismaTable',
-    classes: "table-hover table-dark clickable-table",
+    classes: 'table-hover table-dark clickable-table',
     showColumns: true,
     showExport: true,
     exportFileName: 'GSA_FISMA_Systems_Inventory',
-    headerStyle: "bg-warning",
+    headerStyle: 'bg-warning',
     pagination: true,
     search: true,
     sortName: 'Name',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.fismaUrl
+    url: this.apiService.fismaUrl,
   });
-  
+
   // FISMA System Table Columns
-  columnDefs: any[] = [/* {
+  columnDefs: any[] = [
+    /* {
     field: 'DisplayName',
     title: 'Alias/Acronym',
     sortable: true
   }, */ {
-    field: 'ID',
-    title: 'ID',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Name',
-    title: 'System Name',
-    sortable: true
-  }, {
-    field: 'SystemLevel',
-    title: 'System Level',
-    sortable: true
-  }, {
-    field: 'Status',
-    title: 'Status',
-    sortable: true
-  }, {
-    field: 'ATODate',
-    title: 'ATO Date',
-    sortable: true,
-    formatter: this.sharedService.dateFormatter
-  }, {
-    field: 'RenewalDate',
-    title: 'Renewal Date',
-    sortable: true,
-    formatter: this.sharedService.dateFormatter
-  }, {
-    field: 'ATOType',
-    title: 'ATO Type',
-    sortable: true
-  }, {
-    field: 'FIPS_Impact_Level',
-    title: 'FIPS Impact Level',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: true,
-    visible: false,
-    class: 'text-truncate'
-  }, {
-    field: 'ParentName',
-    title: 'Parent System',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Reportable',
-    title: 'FISMA Reportable',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'PII',
-    title: 'PII',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'CUI',
-    title: 'CUI',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'RespOrg',
-    title: 'Responsible Org',
-    sortable: true,
-    visible: false
-  }/* , {
+      field: 'ID',
+      title: 'ID',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Name',
+      title: 'System Name',
+      sortable: true,
+    },
+    {
+      field: 'SystemLevel',
+      title: 'System Level',
+      sortable: true,
+    },
+    {
+      field: 'Status',
+      title: 'Status',
+      sortable: true,
+    },
+    {
+      field: 'ATODate',
+      title: 'ATO Date',
+      sortable: true,
+      formatter: this.sharedService.dateFormatter,
+    },
+    {
+      field: 'RenewalDate',
+      title: 'Renewal Date',
+      sortable: true,
+      formatter: this.sharedService.dateFormatter,
+    },
+    {
+      field: 'ATOType',
+      title: 'ATO Type',
+      sortable: true,
+    },
+    {
+      field: 'FIPS_Impact_Level',
+      title: 'FIPS Impact Level',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: true,
+      visible: false,
+      class: 'text-truncate',
+    },
+    {
+      field: 'ParentName',
+      title: 'Parent System',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Reportable',
+      title: 'FISMA Reportable',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'PII',
+      title: 'PII',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'CUI',
+      title: 'CUI',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'RespOrg',
+      title: 'Responsible Org',
+      sortable: true,
+      visible: false,
+    } /* , {
     field: 'BusOrg',
     title: 'Business Org',
     sortable: true,
     visible: false
-  } */];
+  } */,
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
-    $('#fismaTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.columnDefs,
-      data: [],
-    }));
+    $('#fismaTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.columnDefs,
+        data: [],
+      })
+    );
 
     // Filter out "Pending" Status
     $(document).ready(
       $('#fismaTable').bootstrapTable('filterBy', {
         Status: 'Active',
-		SystemLevel: 'System',
-    Reportable: 'Yes'
+        SystemLevel: 'System',
+        Reportable: 'Yes',
       })
     );
 
     // Method to handle click events on the FISMA Systems table
     $(document).ready(
-      $('#fismaTable').on('dbl-click-row.bs.table', function (e, row) {
-        this.tableService.fismaTableClick(row);
-      }.bind(this)
-      ));
+      $('#fismaTable').on(
+        'dbl-click-row.bs.table',
+        function (e, row) {
+          this.tableService.fismaTableClick(row);
+        }.bind(this)
+      )
+    );
 
-      // Method to open details modal when referenced directly via URL
-      this.route.params.subscribe(params => {
-        var detailFismaID = params['fismaID'];
-        if (detailFismaID) {
-          this.apiService.getOneFISMASys(detailFismaID).subscribe((data: any[]) => {
+    // Method to open details modal when referenced directly via URL
+    this.route.params.subscribe((params) => {
+      var detailFismaID = params['fismaID'];
+      if (detailFismaID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailFismaID}`
+        );
+        this.apiService
+          .getOneFISMASys(detailFismaID)
+          .subscribe((data: any[]) => {
             this.tableService.fismaTableClick(data[0]);
           });
-        };
-      });  
-
+      }
+    });
   }
 
   // Update table to Retire Systems
   showRetired() {
-    this.retiredTable = true;  // Expose main table button after "Retired" button is pressed
+    this.retiredTable = true; // Expose main table button after "Retired" button is pressed
 
     this.columnDefs.push({
       field: 'InactiveDate',
       title: 'Inactive Date',
       sortable: true,
-      formatter: this.sharedService.dateFormatter
-    })
+      formatter: this.sharedService.dateFormatter,
+    });
 
     // Change columns, filename, and url
     $('#fismaTable').bootstrapTable('refreshOptions', {
       columns: this.columnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Retired_FISMA_Systems')
-      }
+        fileName: this.sharedService.fileNameFmt('GSA_Retired_FISMA_Systems'),
+      },
     });
 
     // Filter to only "Inactive" Status
     $('#fismaTable').bootstrapTable('filterBy', {
-      Status: ['Inactive']
+      Status: ['Inactive'],
     });
   }
 
   backToMainFisma() {
-    this.retiredTable = false;  // Hide main button
+    this.retiredTable = false; // Hide main button
 
     // Change back to default
     this.columnDefs.pop();
     $('#fismaTable').bootstrapTable('refreshOptions', {
       columns: this.columnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_FISMA_Systems_Inventory')
-      }
+        fileName: this.sharedService.fileNameFmt('GSA_FISMA_Systems_Inventory'),
+      },
     });
 
     // Filter back to "Active" Status
     $('#fismaTable').bootstrapTable('filterBy', {
       Status: 'Active',
-	  SystemLevel: 'System'
+      SystemLevel: 'System',
     });
   }
-
 }

--- a/src/app/views/strategy/investments/investments.component.ts
+++ b/src/app/views/strategy/investments/investments.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 import { Investment } from '@api/models/investments.model';
 
@@ -15,10 +16,9 @@ declare var $: any;
 @Component({
   selector: 'investments',
   templateUrl: './investments.component.html',
-  styleUrls: ['./investments.component.css']
+  styleUrls: ['./investments.component.css'],
 })
 export class InvestmentsComponent implements OnInit {
-
   row: Object = <any>{};
   filteredTable: boolean = false;
   filterTitle: string = '';
@@ -26,9 +26,9 @@ export class InvestmentsComponent implements OnInit {
   eliminatedTypes: any[] = ['Eliminated by funding', 'Eliminated by omission'];
 
   vizData: any[] = [];
-  vizLabel: string = 'Total Non-Eliminated Investments'
+  vizLabel: string = 'Total Non-Eliminated Investments';
   colorScheme: {} = {
-    domain: ['#5AA454', '#E44D25', '#CFC0BB', '#7aa3e5', '#a8385d', '#aae3f5']
+    domain: ['#5AA454', '#E44D25', '#CFC0BB', '#7aa3e5', '#a8385d', '#aae3f5'],
   };
 
   constructor(
@@ -38,222 +38,272 @@ export class InvestmentsComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     public sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentInvest.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentInvest.subscribe((row) => (this.row = row));
   }
 
   // Investment Table Options
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'InvestTable',
-    classes: "table-hover table-dark clickable-table",
+    classes: 'table-hover table-dark clickable-table',
     showColumns: true,
     showExport: true,
     exportFileName: 'GSA_IT_Investments',
-    headerStyle: "bg-success",
+    headerStyle: 'bg-success',
     pagination: true,
     search: true,
     sortName: 'Name',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.investUrl
+    url: this.apiService.investUrl,
   });
 
   // Investments Main Table Columns
-  columnDefs: any[] = [{
-    field: 'Name',
-    title: 'Investment Name',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: true,
-    visible: false,
-    class: 'text-truncate'
-  }, {
-    field: 'Type',
-    title: 'Type',
-    sortable: true
-  }, {
-    field: 'IT_Portfolio',
-    title: 'Part of IT Portfolio',
-    sortable: true
-  }, {
-    field: 'Budget_Year',
-    title: 'Budget Year',
-    sortable: true
-  }, {
-    field: 'InvManager',
-    title: 'Investment Manager',
-    sortable: true,
-    formatter: this.sharedService.noneProvidedFormatter
-  }, {
-    field: 'Status',
-    title: 'Status',
-    sortable: true
-  }, {
-    field: 'Start_Year',
-    title: 'Start Year',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'End_Year',
-    title: 'End Year',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'PSA',
-    title: 'Primary Service Area',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Cloud_Alt',
-    title: 'Cloud Alt. Evaluation',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Comments',
-    title: 'Comments',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'UII',
-    title: 'Investment UII',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Updated_Date',
-    title: 'Updated Date',
-    sortable: true,
-    visible: false,
-    formatter: this.sharedService.dateFormatter
-  }];
+  columnDefs: any[] = [
+    {
+      field: 'Name',
+      title: 'Investment Name',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: true,
+      visible: false,
+      class: 'text-truncate',
+    },
+    {
+      field: 'Type',
+      title: 'Type',
+      sortable: true,
+    },
+    {
+      field: 'IT_Portfolio',
+      title: 'Part of IT Portfolio',
+      sortable: true,
+    },
+    {
+      field: 'Budget_Year',
+      title: 'Budget Year',
+      sortable: true,
+    },
+    {
+      field: 'InvManager',
+      title: 'Investment Manager',
+      sortable: true,
+      formatter: this.sharedService.noneProvidedFormatter,
+    },
+    {
+      field: 'Status',
+      title: 'Status',
+      sortable: true,
+    },
+    {
+      field: 'Start_Year',
+      title: 'Start Year',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'End_Year',
+      title: 'End Year',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'PSA',
+      title: 'Primary Service Area',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Cloud_Alt',
+      title: 'Cloud Alt. Evaluation',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Comments',
+      title: 'Comments',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'UII',
+      title: 'Investment UII',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Updated_Date',
+      title: 'Updated Date',
+      sortable: true,
+      visible: false,
+      formatter: this.sharedService.dateFormatter,
+    },
+  ];
 
   // Previous Year Investments Table Columns
-  PYcolumnDefs: any[] = [{
-    field: 'UII',
-    title: 'Investment UII',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Name',
-    title: 'Investment Name',
-    sortable: true
-  }, {
-    field: 'Total_Spend_PY',
-    title: 'Total IT Spending ($ M): PY',
-    sortable: true
-  }, {
-    field: 'DME_Agency_Fund_PY',
-    title: 'DME Agency Funding ($ M): PY',
-    sortable: true
-  }, {
-    field: 'DME_Contributions_PY',
-    title: 'DME Contributions ($ M): PY',
-    sortable: true
-  }, {
-    field: 'OnM_Agency_Fund_PY',
-    title: 'O&M Agency Funding ($ M): PY',
-    sortable: true
-  }, {
-    field: 'OnM_Contributions_PY',
-    title: 'O&M Contributions ($ M): PY',
-    sortable: true
-  }];
+  PYcolumnDefs: any[] = [
+    {
+      field: 'UII',
+      title: 'Investment UII',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Name',
+      title: 'Investment Name',
+      sortable: true,
+    },
+    {
+      field: 'Total_Spend_PY',
+      title: 'Total IT Spending ($ M): PY',
+      sortable: true,
+    },
+    {
+      field: 'DME_Agency_Fund_PY',
+      title: 'DME Agency Funding ($ M): PY',
+      sortable: true,
+    },
+    {
+      field: 'DME_Contributions_PY',
+      title: 'DME Contributions ($ M): PY',
+      sortable: true,
+    },
+    {
+      field: 'OnM_Agency_Fund_PY',
+      title: 'O&M Agency Funding ($ M): PY',
+      sortable: true,
+    },
+    {
+      field: 'OnM_Contributions_PY',
+      title: 'O&M Contributions ($ M): PY',
+      sortable: true,
+    },
+  ];
 
   // Current Year Investments Table Columns
-  CYcolumnDefs: any[] = [{
-    field: 'UII',
-    title: 'Investment UII',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Name',
-    title: 'Investment Name',
-    sortable: true
-  }, {
-    field: 'Total_Spend_CY',
-    title: 'Total IT Spending ($ M): CY',
-    sortable: true
-  }, {
-    field: 'DME_Agency_Fund_CY',
-    title: 'DME Agency Funding ($ M): CY',
-    sortable: true
-  }, {
-    field: 'DME_Contributions_CY',
-    title: 'DME Contributions ($ M): CY',
-    sortable: true
-  }, {
-    field: 'OnM_Agency_Fund_CY',
-    title: 'O&M Agency Funding ($ M): CY',
-    sortable: true
-  }, {
-    field: 'OnM_Contributions_CY',
-    title: 'O&M Contributions ($ M): CY',
-    sortable: true
-  }];
+  CYcolumnDefs: any[] = [
+    {
+      field: 'UII',
+      title: 'Investment UII',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Name',
+      title: 'Investment Name',
+      sortable: true,
+    },
+    {
+      field: 'Total_Spend_CY',
+      title: 'Total IT Spending ($ M): CY',
+      sortable: true,
+    },
+    {
+      field: 'DME_Agency_Fund_CY',
+      title: 'DME Agency Funding ($ M): CY',
+      sortable: true,
+    },
+    {
+      field: 'DME_Contributions_CY',
+      title: 'DME Contributions ($ M): CY',
+      sortable: true,
+    },
+    {
+      field: 'OnM_Agency_Fund_CY',
+      title: 'O&M Agency Funding ($ M): CY',
+      sortable: true,
+    },
+    {
+      field: 'OnM_Contributions_CY',
+      title: 'O&M Contributions ($ M): CY',
+      sortable: true,
+    },
+  ];
 
   // Budget Year Investments Table Columns
-  BYcolumnDefs: any[] = [{
-    field: 'UII',
-    title: 'Investment UII',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Name',
-    title: 'Investment Name',
-    sortable: true
-  }, {
-    field: 'Total_Spend_BY',
-    title: 'Total IT Spending ($ M): BY',
-    sortable: true
-  }, {
-    field: 'DME_Agency_Fund_BY',
-    title: 'DME Agency Funding ($ M): BY',
-    sortable: true
-  }, {
-    field: 'DME_Contributions_BY',
-    title: 'DME Contributions ($ M): BY',
-    sortable: true
-  }, {
-    field: 'DME_Budget_Auth_BY',
-    title: 'DME Budget Authority Agency Funding ($ M): BY',
-    sortable: true
-  }, {
-    field: 'OnM_Agency_Fund_BY',
-    title: 'O&M Agency Funding ($ M): BY',
-    sortable: true
-  }, {
-    field: 'OnM_Contributions_BY',
-    title: 'O&M Contributions ($ M): BY',
-    sortable: true
-  }, {
-    field: 'OnM_Budget_Auth_BY',
-    title: 'O&M Budget Authority Agency Funding ($ M): BY',
-    sortable: true
-  }];
+  BYcolumnDefs: any[] = [
+    {
+      field: 'UII',
+      title: 'Investment UII',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Name',
+      title: 'Investment Name',
+      sortable: true,
+    },
+    {
+      field: 'Total_Spend_BY',
+      title: 'Total IT Spending ($ M): BY',
+      sortable: true,
+    },
+    {
+      field: 'DME_Agency_Fund_BY',
+      title: 'DME Agency Funding ($ M): BY',
+      sortable: true,
+    },
+    {
+      field: 'DME_Contributions_BY',
+      title: 'DME Contributions ($ M): BY',
+      sortable: true,
+    },
+    {
+      field: 'DME_Budget_Auth_BY',
+      title: 'DME Budget Authority Agency Funding ($ M): BY',
+      sortable: true,
+    },
+    {
+      field: 'OnM_Agency_Fund_BY',
+      title: 'O&M Agency Funding ($ M): BY',
+      sortable: true,
+    },
+    {
+      field: 'OnM_Contributions_BY',
+      title: 'O&M Contributions ($ M): BY',
+      sortable: true,
+    },
+    {
+      field: 'OnM_Budget_Auth_BY',
+      title: 'O&M Budget Authority Agency Funding ($ M): BY',
+      sortable: true,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
-    $('#investTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.columnDefs,
-      data: [],
-    }));
+    $('#investTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.columnDefs,
+        data: [],
+      })
+    );
 
     // Filter to only non-eliminated investments
     $(document).ready(
-      $('#investTable').bootstrapTable('filterBy', { Status: this.nonEliminatedTypes })
+      $('#investTable').bootstrapTable('filterBy', {
+        Status: this.nonEliminatedTypes,
+      })
     );
 
     // Method to handle click events on the Investments table
     $(document).ready(
-      $('#investTable').on('click-row.bs.table', function (e, row) {
-        this.tableService.investTableClick(row);
-      }.bind(this))
+      $('#investTable').on(
+        'click-row.bs.table',
+        function (e, row) {
+          this.tableService.investTableClick(row);
+        }.bind(this)
+      )
     );
 
     // Get Investment data for visuals
@@ -270,9 +320,10 @@ export class InvestmentsComponent implements OnInit {
       }, {});
 
       // Resolve the counts into an object and sort by value
-      this.vizData = Object.keys(counts).map(k => {
-        return { name: k, value: counts[k] };
-      })
+      this.vizData = Object.keys(counts)
+        .map((k) => {
+          return { name: k, value: counts[k] };
+        })
         .sort(function (a, b) {
           return b.value - a.value;
         });
@@ -281,110 +332,128 @@ export class InvestmentsComponent implements OnInit {
     });
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailInvestID = params['investID'];
       if (detailInvestID) {
-        this.apiService.getOneInvest(detailInvestID).subscribe((data: any[]) => {
-          this.tableService.investTableClick(data[0]);
-        });
-      };
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailInvestID}`
+        );
+        this.apiService
+          .getOneInvest(detailInvestID)
+          .subscribe((data: any[]) => {
+            this.tableService.investTableClick(data[0]);
+          });
+      }
     });
-
   }
 
   // Update table from filter buttons
   eliminatedFilter() {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     this.filterTitle = 'Eliminated';
 
     // Hide visualization when on eliminated items
     $('#investViz').collapse('hide');
 
-    $('#investTable').bootstrapTable('filterBy', { Status: this.eliminatedTypes });
+    $('#investTable').bootstrapTable('filterBy', {
+      Status: this.eliminatedTypes,
+    });
     $('#investTable').bootstrapTable('refreshOptions', {
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Eliminated_IT_Investments')
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Eliminated_IT_Investments'
+        ),
+      },
     });
   }
 
   previousYearFilter() {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     this.filterTitle = 'Previous Year';
 
     // Hide visualization
     $('#investViz').collapse('hide');
 
-    $('#investTable').bootstrapTable('filterBy', { });
+    $('#investTable').bootstrapTable('filterBy', {});
     $('#investTable').bootstrapTable('refreshOptions', {
       columns: this.PYcolumnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Previous_Year_IT_Investments')
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Previous_Year_IT_Investments'
+        ),
+      },
     });
   }
 
   currentYearFilter() {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     this.filterTitle = 'Current Year';
 
     // Hide visualization when on eliminated items
     $('#investViz').collapse('hide');
 
-    $('#investTable').bootstrapTable('filterBy', { });
+    $('#investTable').bootstrapTable('filterBy', {});
     $('#investTable').bootstrapTable('refreshOptions', {
       columns: this.CYcolumnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Current_Year_IT_Investments')
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Current_Year_IT_Investments'
+        ),
+      },
     });
   }
 
   budgetYearFilter() {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     this.filterTitle = 'Budget Year';
 
     // Hide visualization
     $('#investViz').collapse('hide');
 
-    $('#investTable').bootstrapTable('filterBy', { });
+    $('#investTable').bootstrapTable('filterBy', {});
     $('#investTable').bootstrapTable('refreshOptions', {
       columns: this.BYcolumnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Budget_Year_IT_Investments')
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Budget_Year_IT_Investments'
+        ),
+      },
     });
   }
 
   backToMainInvest() {
-    this.filteredTable = false;  // Hide main button
+    this.filteredTable = false; // Hide main button
     this.filterTitle = '';
 
     $('#investViz').collapse('show');
 
     // Remove filters and back to default
-    $('#investTable').bootstrapTable('filterBy', { Status: this.nonEliminatedTypes });
+    $('#investTable').bootstrapTable('filterBy', {
+      Status: this.nonEliminatedTypes,
+    });
     $('#investTable').bootstrapTable('refreshOptions', {
       columns: this.columnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_IT_Investments')
-      }
+        fileName: this.sharedService.fileNameFmt('GSA_IT_Investments'),
+      },
     });
   }
 
   onSelect(chartData): void {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     this.filterTitle = chartData.name;
 
     // Filter by Type clicked on visualization
     $('#investTable').bootstrapTable('filterBy', {
       Status: this.nonEliminatedTypes,
-      Type: chartData.name
+      Type: chartData.name,
     });
     $('#investTable').bootstrapTable('refreshOptions', {
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_IT_Investments-' + chartData.name)
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_IT_Investments-' + chartData.name
+        ),
+      },
     });
   }
 }

--- a/src/app/views/systems/records-management/records-management.component.ts
+++ b/src/app/views/systems/records-management/records-management.component.ts
@@ -2,10 +2,11 @@ import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { ApiService } from "@services/apis/api.service";
+import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -13,10 +14,9 @@ declare var $: any;
 @Component({
   selector: 'records-management',
   templateUrl: './records-management.component.html',
-  styleUrls: ['./records-management.component.css']
+  styleUrls: ['./records-management.component.css'],
 })
 export class RecordsManagementComponent implements OnInit {
-
   constructor(
     private apiService: ApiService,
     private location: Location,
@@ -24,124 +24,148 @@ export class RecordsManagementComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     public sharedService: SharedService,
-    private tableService: TableService) { }
+    private tableService: TableService,
+    private titleService: Title
+  ) {}
 
   // Records Table Options
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'RecordsTable',
-    classes: "table-hover table-dark clickable-table",
+    classes: 'table-hover table-dark clickable-table',
     showColumns: true,
     showExport: true,
     exportFileName: 'GSA_Record_Schedules',
-    headerStyle: "bg-danger",
+    headerStyle: 'bg-danger',
     pagination: true,
     search: true,
     sortName: 'GSA_Number',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.recordsUrl
+    url: this.apiService.recordsUrl,
   });
 
   // Apps Table Columns
-  columnDefs: any[] = [{
-    field: 'GSA_Number',
-    title: 'GSA Number',
-    sortable: true
-  }, {
-    field: 'Record_Item_Title',
-    title: 'Record Title',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: false,
-    class: 'text-wrap'
-  }, {
-    field: 'Record_Status',
-    title: 'Status',
-	  visible: false,
-    sortable: true
-  }, {
-    field: 'RG',
-    title: 'Record Group',
-	  visible: false,
-    sortable: true
-  }, {
-    field: 'Retention_Instructions',
-    title: 'Retention Instructions',
-    sortable: false,
-    visible: false,
-    class: 'text-truncate'
-  }, {
-    field: 'Legal_Disposition_Authority',
-    title: 'Disposition Authority (DA)',
-    sortable: true
-  }, {
-    field: 'Type_Disposition',
-    title: 'Disposition Type',
-    visible: false,
-    sortable: true
-  }, {
-    field: 'Date_DA_Approved',
-    title: 'DA Approval Date',
-	  visible: false,
-    sortable: true
-  }, {
-    field: 'Disposition_Notes',
-    title: 'Disposition Notes',
-    sortable: false,
-    visible: false,
-    class: 'text-truncate'
-  }, {
-    field: 'FP_Category',
-    title: 'FP Category',
-	  visible: false,
-    sortable: true
-  }, {
-    field: 'PII',
-    title: 'PII',
-    sortable: true
-  }, {
-    field: 'CUI',
-    title: 'CUI',
-    sortable: true
-  }, {
-    field: 'FY_Retention_Years',
-    title: 'Retention Years',
-    sortable: true
-  }];
+  columnDefs: any[] = [
+    {
+      field: 'GSA_Number',
+      title: 'GSA Number',
+      sortable: true,
+    },
+    {
+      field: 'Record_Item_Title',
+      title: 'Record Title',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: false,
+      class: 'text-wrap',
+    },
+    {
+      field: 'Record_Status',
+      title: 'Status',
+      visible: false,
+      sortable: true,
+    },
+    {
+      field: 'RG',
+      title: 'Record Group',
+      visible: false,
+      sortable: true,
+    },
+    {
+      field: 'Retention_Instructions',
+      title: 'Retention Instructions',
+      sortable: false,
+      visible: false,
+      class: 'text-truncate',
+    },
+    {
+      field: 'Legal_Disposition_Authority',
+      title: 'Disposition Authority (DA)',
+      sortable: true,
+    },
+    {
+      field: 'Type_Disposition',
+      title: 'Disposition Type',
+      visible: false,
+      sortable: true,
+    },
+    {
+      field: 'Date_DA_Approved',
+      title: 'DA Approval Date',
+      visible: false,
+      sortable: true,
+    },
+    {
+      field: 'Disposition_Notes',
+      title: 'Disposition Notes',
+      sortable: false,
+      visible: false,
+      class: 'text-truncate',
+    },
+    {
+      field: 'FP_Category',
+      title: 'FP Category',
+      visible: false,
+      sortable: true,
+    },
+    {
+      field: 'PII',
+      title: 'PII',
+      sortable: true,
+    },
+    {
+      field: 'CUI',
+      title: 'CUI',
+      sortable: true,
+    },
+    {
+      field: 'FY_Retention_Years',
+      title: 'Retention Years',
+      sortable: true,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
     // Set JWT when logged into GEAR Manager when returning from secureAuth
     this.sharedService.setJWTonLogIn();
 
-    $('#recordsTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.columnDefs,
-      data: [],
-    }));
+    $('#recordsTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.columnDefs,
+        data: [],
+      })
+    );
 
     // Method to handle click events on the Records table
     $(document).ready(
-      $('#recordsTable').on('click-row.bs.table', function (e, row) {
-        this.tableService.recordsTableClick(row);
-      }.bind(this),
-      ));
+      $('#recordsTable').on(
+        'click-row.bs.table',
+        function (e, row) {
+          this.tableService.recordsTableClick(row);
+        }.bind(this)
+      )
+    );
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailrecID = params['recID'];
       if (detailrecID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailrecID}`
+        );
         this.apiService.getOneRecord(detailrecID).subscribe((data: any[]) => {
           this.tableService.recordsTableClick(data[0]);
         });
-      };
+      }
     });
   }
-
 }

--- a/src/app/views/systems/systems/systems.component.ts
+++ b/src/app/views/systems/systems/systems.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 import { System } from '@api/models/systems.model';
 
@@ -19,10 +20,9 @@ declare var $: any;
 @Component({
   selector: 'systems',
   templateUrl: './systems.component.html',
-  styleUrls: ['./systems.component.css']
+  styleUrls: ['./systems.component.css'],
 })
 export class SystemsComponent implements OnInit {
-
   row: Object = <any>{};
   filteredTable: boolean = false;
   filterTitle: string = '';
@@ -32,9 +32,9 @@ export class SystemsComponent implements OnInit {
   pendingTable: boolean = false;
 
   vizData: any[] = [];
-  vizLabel: string = 'Total Active Systems'
+  vizLabel: string = 'Total Active Systems';
   colorScheme: {} = {
-    domain: ['#5AA454', '#E44D25', '#CFC0BB', '#7aa3e5', '#a8385d', '#aae3f5']
+    domain: ['#5AA454', '#E44D25', '#CFC0BB', '#7aa3e5', '#a8385d', '#aae3f5'],
   };
 
   constructor(
@@ -44,230 +44,272 @@ export class SystemsComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     public sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentSys.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentSys.subscribe((row) => (this.row = row));
   }
 
   // Systems Table Options
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'SystemTable',
-    classes: "table-hover table-dark clickable-table",
+    classes: 'table-hover table-dark clickable-table',
     showColumns: true,
     showExport: true,
     exportFileName: 'GSA_Systems_SubSystems',
-    headerStyle: "bg-danger",
+    headerStyle: 'bg-danger',
     pagination: true,
     search: true,
     sortName: 'Name',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.sysUrl
+    url: this.apiService.sysUrl,
   });
 
   // Systems Table Columns
-  columnDefs: any[] = [{
-    field: 'ID',
-    title: 'ID',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'DisplayName',
-    title: 'Alias/Acronym',
-    sortable: true
-  }, {
-    field: 'Name',
-    title: 'System Name',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: true,
-    visible: false,
-    class: 'text-wrap'
-  }, {
-    field: 'SystemLevel',
-    title: 'System Level',
-    sortable: true
-  }, {
-    field: 'Status',
-    title: 'Status',
-    sortable: true
-  }, {
-    field: 'RespOrg',
-    title: 'Responsible Org',
-    sortable: true
-  }, {
-    field: 'BusOrg',
-    title: 'Business Org',
-    sortable: true
-  }, {
-    field: 'ParentName',
-    title: 'Parent System',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'CSP',
-    title: 'Hosting Provider',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'CloudYN',
-    title: 'Cloud Hosted?',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'AO',
-    title: 'Authorizing Official',
-    sortable: true,
-    visible: false,
-    formatter: this.sharedService.pocStringNameFormatter
-  }, {
-    field: 'SO',
-    title: 'System Owner',
-    sortable: true,
-    visible: false,
-    formatter: this.sharedService.pocStringNameFormatter
-  }, {
-    field: 'BusPOC',
-    title: 'Business POC',
-    sortable: true,
-    visible: false,
-    formatter: this.sharedService.pocStringNameFormatter
-  }, {
-    field: 'TechPOC',
-    title: 'Technical POC',
-    sortable: true,
-    visible: false,
-    formatter: this.sharedService.pocStringNameFormatter
-  }];
+  columnDefs: any[] = [
+    {
+      field: 'ID',
+      title: 'ID',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'DisplayName',
+      title: 'Alias/Acronym',
+      sortable: true,
+    },
+    {
+      field: 'Name',
+      title: 'System Name',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: true,
+      visible: false,
+      class: 'text-wrap',
+    },
+    {
+      field: 'SystemLevel',
+      title: 'System Level',
+      sortable: true,
+    },
+    {
+      field: 'Status',
+      title: 'Status',
+      sortable: true,
+    },
+    {
+      field: 'RespOrg',
+      title: 'Responsible Org',
+      sortable: true,
+    },
+    {
+      field: 'BusOrg',
+      title: 'Business Org',
+      sortable: true,
+    },
+    {
+      field: 'ParentName',
+      title: 'Parent System',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'CSP',
+      title: 'Hosting Provider',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'CloudYN',
+      title: 'Cloud Hosted?',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'AO',
+      title: 'Authorizing Official',
+      sortable: true,
+      visible: false,
+      formatter: this.sharedService.pocStringNameFormatter,
+    },
+    {
+      field: 'SO',
+      title: 'System Owner',
+      sortable: true,
+      visible: false,
+      formatter: this.sharedService.pocStringNameFormatter,
+    },
+    {
+      field: 'BusPOC',
+      title: 'Business POC',
+      sortable: true,
+      visible: false,
+      formatter: this.sharedService.pocStringNameFormatter,
+    },
+    {
+      field: 'TechPOC',
+      title: 'Technical POC',
+      sortable: true,
+      visible: false,
+      formatter: this.sharedService.pocStringNameFormatter,
+    },
+  ];
 
   // Inactive Column Defs
-  inactiveColumnDefs: any[] = [{
-    field: 'Name',
-    title: 'System Name',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: true,
-    visible: false,
-    class: 'text-truncate'
-  }, {
-    field: 'SystemLevel',
-    title: 'System Level',
-    sortable: true
-  }, {
-    field: 'Status',
-    title: 'Status',
-    sortable: true
-  }, {
-    field: 'RespOrg',
-    title: 'Responsible Org',
-    sortable: true
-  }, {
-    field: 'BusOrg',
-    title: 'Business Org',
-    sortable: true
-  }, {
-    field: 'CSP',
-    title: 'Cloud Server Provider',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'CloudYN',
-    title: 'Cloud Hosted?',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'AO',
-    title: 'Authorizing Official',
-    sortable: true,
-    visible: false,
-    formatter: this.sharedService.pocStringNameFormatter
-  }, {
-    field: 'SO',
-    title: 'System Owner',
-    sortable: true,
-    visible: false,
-    formatter: this.sharedService.pocStringNameFormatter
-  }, {
-    field: 'InactiveDate',
-    title: 'Inactive Date',
-    sortable: true,
-    formatter: this.sharedService.dateFormatter
-  }];
+  inactiveColumnDefs: any[] = [
+    {
+      field: 'Name',
+      title: 'System Name',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: true,
+      visible: false,
+      class: 'text-truncate',
+    },
+    {
+      field: 'SystemLevel',
+      title: 'System Level',
+      sortable: true,
+    },
+    {
+      field: 'Status',
+      title: 'Status',
+      sortable: true,
+    },
+    {
+      field: 'RespOrg',
+      title: 'Responsible Org',
+      sortable: true,
+    },
+    {
+      field: 'BusOrg',
+      title: 'Business Org',
+      sortable: true,
+    },
+    {
+      field: 'CSP',
+      title: 'Cloud Server Provider',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'CloudYN',
+      title: 'Cloud Hosted?',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'AO',
+      title: 'Authorizing Official',
+      sortable: true,
+      visible: false,
+      formatter: this.sharedService.pocStringNameFormatter,
+    },
+    {
+      field: 'SO',
+      title: 'System Owner',
+      sortable: true,
+      visible: false,
+      formatter: this.sharedService.pocStringNameFormatter,
+    },
+    {
+      field: 'InactiveDate',
+      title: 'Inactive Date',
+      sortable: true,
+      formatter: this.sharedService.dateFormatter,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
       $('[data-toggle="popover"]').popover();
     });
-    
+
     // Set JWT when logged into GEAR Manager when returning from secureAuth
     this.sharedService.setJWTonLogIn();
 
-    $('#systemTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.columnDefs,
-      data: [],
-    }));
+    $('#systemTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.columnDefs,
+        data: [],
+      })
+    );
 
     // Filter to only active systems
     $(document).ready(
-      $('#systemTable').bootstrapTable('filterBy', { 
-		Status: 'Active',
-		BusApp: 'Yes'
-		})
+      $('#systemTable').bootstrapTable('filterBy', {
+        Status: 'Active',
+        BusApp: 'Yes',
+      })
     );
 
     // Method to handle click events on the Systems table
     $(document).ready(
-      $('#systemTable').on('click-row.bs.table', function (e, row) {
-        this.tableService.systemsTableClick(row);
-        // this.getInterfaceData(row.ID);
-      }.bind(this)
-      ));
+      $('#systemTable').on(
+        'click-row.bs.table',
+        function (e, row) {
+          this.tableService.systemsTableClick(row);
+          // this.getInterfaceData(row.ID);
+        }.bind(this)
+      )
+    );
 
-  // Get System data for visuals
-  this.apiService.getSystems().subscribe((data: any[]) => {
-    // Get counts by SSO
-    var counts = data.reduce((p, c) => {
-      var name = c.RespOrg;
-      if (!p.hasOwnProperty(name) && c.Status == 'Active' && c.BusApp == 'Yes') {
-        p[name] = 0;
-      }
-      // Only count if Status is Active
-      if (c.Status == 'Active' && c.BusApp == 'Yes') p[name]++;
-      return p;
-    }, {});
+    // Get System data for visuals
+    this.apiService.getSystems().subscribe((data: any[]) => {
+      // Get counts by SSO
+      var counts = data.reduce((p, c) => {
+        var name = c.RespOrg;
+        if (
+          !p.hasOwnProperty(name) &&
+          c.Status == 'Active' &&
+          c.BusApp == 'Yes'
+        ) {
+          p[name] = 0;
+        }
+        // Only count if Status is Active
+        if (c.Status == 'Active' && c.BusApp == 'Yes') p[name]++;
+        return p;
+      }, {});
 
-    // Resolve the counts into an object and sort by value
-    this.vizData = Object.keys(counts).map(k => {
-      return { name: k, value: counts[k] };
-    })
-      .sort(function (a, b) {
-        return b.value - a.value;
-      });
+      // Resolve the counts into an object and sort by value
+      this.vizData = Object.keys(counts)
+        .map((k) => {
+          return { name: k, value: counts[k] };
+        })
+        .sort(function (a, b) {
+          return b.value - a.value;
+        });
 
-    // console.log(this.vizData);  // Debug
-  });
+      // console.log(this.vizData);  // Debug
+    });
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailSysID = params['sysID'];
       if (detailSysID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailSysID}`
+        );
         this.apiService.getOneSys(detailSysID).subscribe((data: any[]) => {
           this.tableService.systemsTableClick(data[0]);
           // this.getInterfaceData(row.ID);
         });
-      };
+      }
     });
-
   }
 
   // Update table from filter buttons if only filtering ONE column. Not currently used in business systems report.
   changeFilter(field: string, term: string) {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     var filter = {};
     filter[field] = term;
     var title = '';
@@ -285,12 +327,14 @@ export class SystemsComponent implements OnInit {
         title = term + ' GSA';
         activeColDef = this.inactiveColumnDefs;
         break;
-    };
+    }
     $('#systemTable').bootstrapTable('refreshOptions', {
       columns: activeColDef,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt(`GSA_${title.replace(' ', '_')}_Systems`)
-      }
+        fileName: this.sharedService.fileNameFmt(
+          `GSA_${title.replace(' ', '_')}_Systems`
+        ),
+      },
     });
     this.filterTitle = title;
   }
@@ -298,7 +342,7 @@ export class SystemsComponent implements OnInit {
   //The following is adapted from fisma.component.ts to filter on multiple columns of data rather than one
   // Update table to Cloud Business Systems
   showCloud() {
-    this.filteredTable = true;  // Expose main table button after "Cloud Enabled" button is pressed
+    this.filteredTable = true; // Expose main table button after "Cloud Enabled" button is pressed
     this.filterTitle = 'Cloud GSA';
 
     // Hide visualization when on alternative filters
@@ -308,21 +352,21 @@ export class SystemsComponent implements OnInit {
     $('#systemTable').bootstrapTable('refreshOptions', {
       columns: this.columnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Cloud_Business_Systems')
-      }
+        fileName: this.sharedService.fileNameFmt('GSA_Cloud_Business_Systems'),
+      },
     });
 
     // Filter to only "Cloud" Business Systems/Subsystems
     $('#systemTable').bootstrapTable('filterBy', {
       Status: ['Active'],
-	    BusApp: 'Yes',
-      CloudYN: 'Yes'
+      BusApp: 'Yes',
+      CloudYN: 'Yes',
     });
   }
 
   // Update table to Inactive Business Systems
   showInactive() {
-    this.filteredTable = true;  // Expose main table button after "Inactive" button is pressed
+    this.filteredTable = true; // Expose main table button after "Inactive" button is pressed
     this.filterTitle = 'Inactive GSA';
 
     // Hide visualization when on alternative filters
@@ -332,20 +376,22 @@ export class SystemsComponent implements OnInit {
     $('#systemTable').bootstrapTable('refreshOptions', {
       columns: this.columnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Inactive_Business_Systems')
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Inactive_Business_Systems'
+        ),
+      },
     });
 
     // Filter to only "Inactive" Business Systems/Subsystems
     $('#systemTable').bootstrapTable('filterBy', {
       Status: ['Inactive'],
-	    BusApp: 'Yes'
+      BusApp: 'Yes',
     });
   }
 
   // Update table to Pending Business Systems
   showPending() {
-    this.filteredTable = true;  // Expose main table button after "Pending" button is pressed
+    this.filteredTable = true; // Expose main table button after "Pending" button is pressed
     this.filterTitle = 'Pending GSA';
 
     // Hide visualization when on alternative filters
@@ -355,208 +401,211 @@ export class SystemsComponent implements OnInit {
     $('#systemTable').bootstrapTable('refreshOptions', {
       columns: this.columnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Pending_Business_Systems')
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Pending_Business_Systems'
+        ),
+      },
     });
 
     // Filter to only "Pending" Business Systems/Subsystems
     $('#systemTable').bootstrapTable('filterBy', {
-      Status: ['Pending']//,
+      Status: ['Pending'], //,
       //Commenting out BusApp: 'Yes' since pending systems need to be reviewed by EA and Security of whether they are a business system.
-	    //BusApp: 'Yes'
+      //BusApp: 'Yes'
     });
   }
- //The preceding code is adapted from fisma.component.ts to filter on multiple columns of data rather than one 
+  //The preceding code is adapted from fisma.component.ts to filter on multiple columns of data rather than one
 
   backToMainSys() {
-    this.filteredTable = false;  // Hide main button
+    this.filteredTable = false; // Hide main button
 
     $('#sysViz').collapse('show');
 
     // Remove filters and back to default
-    $('#systemTable').bootstrapTable('filterBy', { 
-		Status: 'Active', 
-		BusApp: 'Yes'
-		});
+    $('#systemTable').bootstrapTable('filterBy', {
+      Status: 'Active',
+      BusApp: 'Yes',
+    });
     $('#systemTable').bootstrapTable('refreshOptions', {
       columns: this.columnDefs,
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Systems_SubSystems')
-      }
+        fileName: this.sharedService.fileNameFmt('GSA_Systems_SubSystems'),
+      },
     });
   }
 
   onSelect(chartData): void {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     this.filterTitle = chartData.name;
 
     // Filter by RespOrg clicked on visualization
     $('#systemTable').bootstrapTable('filterBy', {
       Status: ['Active'],
-	    BusApp: 'Yes',
-      RespOrg: chartData.name
+      BusApp: 'Yes',
+      RespOrg: chartData.name,
     });
     $('#systemTable').bootstrapTable('refreshOptions', {
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_Systems_SubSystems-' + chartData.name)
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_Systems_SubSystems-' + chartData.name
+        ),
+      },
     });
   }
 
-//   private getInterfaceData(sysID: number) {
-//     this.apiService.getOneDataFlow(sysID).subscribe((data: any[]) => {
-//       this.interfaces = data;
-//       this.modalService.updateDetails(this.interfaces, 'data-flow');
-//       if (this.interfaces.length) this.createDataFlowChart(sysID);  // If there is interface data, create the flow chart
-//     });
-//   }
+  //   private getInterfaceData(sysID: number) {
+  //     this.apiService.getOneDataFlow(sysID).subscribe((data: any[]) => {
+  //       this.interfaces = data;
+  //       this.modalService.updateDetails(this.interfaces, 'data-flow');
+  //       if (this.interfaces.length) this.createDataFlowChart(sysID);  // If there is interface data, create the flow chart
+  //     });
+  //   }
 
-//   private createDataFlowChart(sysID: number) {
-//     // console.log(sysID, this.interfaces);  // Debug
+  //   private createDataFlowChart(sysID: number) {
+  //     // console.log(sysID, this.interfaces);  // Debug
 
-//     var CONTAINER_ID = '#dataFlowChart',
-//       SVG_ID = 'dataflowSVG',
-//       units = "Connections",
+  //     var CONTAINER_ID = '#dataFlowChart',
+  //       SVG_ID = 'dataflowSVG',
+  //       units = "Connections",
 
-//       // Set the dimensions and margins of the graph
-//       margin = { top: 20, right: 20, bottom: 20, left: 20 },
-//       width = 960,
-//       height = 500,
-//       nodeWidth = 36,
-//       nodePadding = 40;
+  //       // Set the dimensions and margins of the graph
+  //       margin = { top: 20, right: 20, bottom: 20, left: 20 },
+  //       width = 960,
+  //       height = 500,
+  //       nodeWidth = 36,
+  //       nodePadding = 40;
 
-//     if (document.getElementById(SVG_ID)) {
-//       return false;
-//     };
+  //     if (document.getElementById(SVG_ID)) {
+  //       return false;
+  //     };
 
-//     // Make sure element is empty first
-//     d3.select(CONTAINER_ID + "> svg").remove();
+  //     // Make sure element is empty first
+  //     d3.select(CONTAINER_ID + "> svg").remove();
 
-//     // Append the svg object to the body of the page
-//     var svg = d3.select(CONTAINER_ID).append("svg")
-//       .attr('width', width)
-//       .attr('height', height);
+  //     // Append the svg object to the body of the page
+  //     var svg = d3.select(CONTAINER_ID).append("svg")
+  //       .attr('width', width)
+  //       .attr('height', height);
 
-//     var g = svg.append("g")
-//       .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
+  //     var g = svg.append("g")
+  //       .attr("transform", "translate(" + margin.left + "," + margin.top + ")")
 
-//     // Format variables
-//     var formatNumber = d3.format(",.0f"),    // zero decimal places
-//       format = function (d) { return formatNumber(d) + " " + units; },
-//       color = d3.scaleOrdinal()
-//         .range(['#9dc6d8', '#00b3ca', '#7dd0b6', '#1d4e89',
-//           '#d2b29b', '#e38690', '#f69256', '#ead98b', '#965251',
-//           '#c6cccc', '#e5dfef', '#fbdce0', '#cbefe7', '#fffdce',
-//           '#d7ffdd',
-//         ]);
+  //     // Format variables
+  //     var formatNumber = d3.format(",.0f"),    // zero decimal places
+  //       format = function (d) { return formatNumber(d) + " " + units; },
+  //       color = d3.scaleOrdinal()
+  //         .range(['#9dc6d8', '#00b3ca', '#7dd0b6', '#1d4e89',
+  //           '#d2b29b', '#e38690', '#f69256', '#ead98b', '#965251',
+  //           '#c6cccc', '#e5dfef', '#fbdce0', '#cbefe7', '#fffdce',
+  //           '#d7ffdd',
+  //         ]);
 
-//     // Set the sankey diagram properties
-//     var sankey = d3Sankey.sankey()
-//       .nodeWidth(nodeWidth)
-//       .nodePadding(nodePadding)
-//       .size([width - margin.left - margin.right,
-//       height - margin.top - margin.bottom])
-//       .nodeId(function (d: any) {
-//         return d.name;
-//       });
+  //     // Set the sankey diagram properties
+  //     var sankey = d3Sankey.sankey()
+  //       .nodeWidth(nodeWidth)
+  //       .nodePadding(nodePadding)
+  //       .size([width - margin.left - margin.right,
+  //       height - margin.top - margin.bottom])
+  //       .nodeId(function (d: any) {
+  //         return d.name;
+  //       });
 
-//     var link = g.append("g")
-//       .attr("class", "link")
-//       .selectAll("path");
+  //     var link = g.append("g")
+  //       .attr("class", "link")
+  //       .selectAll("path");
 
-//     var node = g.append("g")
-//       .attr("class", "node")
-//       .selectAll("g");
+  //     var node = g.append("g")
+  //       .attr("class", "node")
+  //       .selectAll("g");
 
-//     // load the data
-//     //set up graph in same style as original example but empty
-//     var graph = {
-//       "nodes": [],
-//       "links": []
-//     };
+  //     // load the data
+  //     //set up graph in same style as original example but empty
+  //     var graph = {
+  //       "nodes": [],
+  //       "links": []
+  //     };
 
-//     this.interfaces.forEach(function (d) {
-//       graph.nodes.push({
-//         "name": d.srcApp,
-//         "id": d.srcAppID
-//       });
-//       graph.nodes.push({
-//         "name": d.destApp,
-//         "id": d.destAppID
-//       });
-//       graph.links.push({
-//         "source": d.srcApp,
-//         "target": d.destApp,
-//         "sourceId": d.srcAppID,
-//         "targetId": d.destAppID,
-//         "value": 1
-//       });
-//     });
+  //     this.interfaces.forEach(function (d) {
+  //       graph.nodes.push({
+  //         "name": d.srcApp,
+  //         "id": d.srcAppID
+  //       });
+  //       graph.nodes.push({
+  //         "name": d.destApp,
+  //         "id": d.destAppID
+  //       });
+  //       graph.links.push({
+  //         "source": d.srcApp,
+  //         "target": d.destApp,
+  //         "sourceId": d.srcAppID,
+  //         "targetId": d.destAppID,
+  //         "value": 1
+  //       });
+  //     });
 
-//     // return only the distinct / unique nodes
-//     graph.nodes = Array.from(new Set(graph.nodes.map(node => node.name)))
-//       .map(name => {
-//         return graph.nodes.find(node => node.name === name)
-//       });
+  //     // return only the distinct / unique nodes
+  //     graph.nodes = Array.from(new Set(graph.nodes.map(node => node.name)))
+  //       .map(name => {
+  //         return graph.nodes.find(node => node.name === name)
+  //       });
 
-//     // console.log("graph: ", graph);  // Debug
+  //     // console.log("graph: ", graph);  // Debug
 
-//     sankey(graph);
+  //     sankey(graph);
 
-//     // Add in the links
-//     link = link.data(graph.links)
-//       .enter().append("path")
-//       .attr("d", d3Sankey.sankeyLinkHorizontal())
-//       .style("fill", "none")
-//       // Change path color by target
-//       .style("stroke", function (d: any) {
-//         return d.color = color(d.targetId);
-//       })
-//       .style("stroke-opacity", 0.7)
-//       // Path width is default or width if value is valid
-//       .style("stroke-width", function (d: any) {
-//         return Math.max(15, d.width);
-//       });
+  //     // Add in the links
+  //     link = link.data(graph.links)
+  //       .enter().append("path")
+  //       .attr("d", d3Sankey.sankeyLinkHorizontal())
+  //       .style("fill", "none")
+  //       // Change path color by target
+  //       .style("stroke", function (d: any) {
+  //         return d.color = color(d.targetId);
+  //       })
+  //       .style("stroke-opacity", 0.7)
+  //       // Path width is default or width if value is valid
+  //       .style("stroke-width", function (d: any) {
+  //         return Math.max(15, d.width);
+  //       });
 
-//     // Add the link titles
-//     link.append("title")
-//       .text(function (d: any) {
-//         return d.source.name + " → " +
-//           d.target.name + "\n" + format(d.value)
-//       });
+  //     // Add the link titles
+  //     link.append("title")
+  //       .text(function (d: any) {
+  //         return d.source.name + " → " +
+  //           d.target.name + "\n" + format(d.value)
+  //       });
 
-//     // Add in the nodes
-//     node = node.data(graph.nodes)
-//       .enter().append("g")
-//       .on("click", function (d: any) {
-//         //Open new modal when selecting app on interface graphic
-//         $('#sysDetail').modal('hide');
+  //     // Add in the nodes
+  //     node = node.data(graph.nodes)
+  //       .enter().append("g")
+  //       .on("click", function (d: any) {
+  //         //Open new modal when selecting app on interface graphic
+  //         $('#sysDetail').modal('hide');
 
-//         // Route to new app detail
-//         window.location.href = `#/systems/${d.id}`;
-//         window.location.reload();
-//       }.bind(this));
+  //         // Route to new app detail
+  //         window.location.href = `#/systems/${d.id}`;
+  //         window.location.reload();
+  //       }.bind(this));
 
-//     // add the rectangles for the nodes
-//     node.append("rect")
-//       .attr("x", function (d) { return d.x0; }) //Use original sankey defined positions
-//       .attr("y", function (d) { return d.y0 - (Math.max(30, d.height) / 2); }) //Use force defined positions
-//       .attr("height", function (d) { return Math.max(30, d.height); })
-//       .attr("width", function (d) { return d.x1 - d.x0; })
-//       .style("fill", function (d) { return color(d.id); })
-//       .style("opacity", 0.5)
-//       .style("stroke", "white");
+  //     // add the rectangles for the nodes
+  //     node.append("rect")
+  //       .attr("x", function (d) { return d.x0; }) //Use original sankey defined positions
+  //       .attr("y", function (d) { return d.y0 - (Math.max(30, d.height) / 2); }) //Use force defined positions
+  //       .attr("height", function (d) { return Math.max(30, d.height); })
+  //       .attr("width", function (d) { return d.x1 - d.x0; })
+  //       .style("fill", function (d) { return color(d.id); })
+  //       .style("opacity", 0.5)
+  //       .style("stroke", "white");
 
-//     // add in the title for the nodes
-//     node.append("text")
-//       .attr("x", function (d) { return d.x0 - 6; })
-//       .attr("y", function (d) { return d.y0 + ((d.y1 - d.y0) / 2); })
-//       .attr("dy", "0.35em")
-//       .attr("text-anchor", "end")
-//       .text(function (d) { return d.name; })
-//       .filter(function (d) { return d.x0 < width / 2; })
-//       .attr("x", function (d) { return d.x1 + 6; })
-//       .attr("text-anchor", "start");
-//   }
-
+  //     // add in the title for the nodes
+  //     node.append("text")
+  //       .attr("x", function (d) { return d.x0 - 6; })
+  //       .attr("y", function (d) { return d.y0 + ((d.y1 - d.y0) / 2); })
+  //       .attr("dy", "0.35em")
+  //       .attr("text-anchor", "end")
+  //       .text(function (d) { return d.name; })
+  //       .filter(function (d) { return d.x0 < width / 2; })
+  //       .attr("x", function (d) { return d.x1 + 6; })
+  //       .attr("text-anchor", "start");
+  //   }
 }

--- a/src/app/views/systems/time/time.component.ts
+++ b/src/app/views/systems/time/time.component.ts
@@ -8,6 +8,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -15,10 +16,9 @@ declare var $: any;
 @Component({
   selector: 'time',
   templateUrl: './time.component.html',
-  styleUrls: ['./time.component.css']
+  styleUrls: ['./time.component.css'],
 })
 export class TimeComponent implements OnInit {
-
   row: Object = <any>{};
 
   vizData: any[] = [];
@@ -44,11 +44,13 @@ export class TimeComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentSys.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentSys.subscribe((row) => (this.row = row));
 
     Object.assign(this, {
-      colorSets
+      colorSets,
     });
   }
 
@@ -56,106 +58,127 @@ export class TimeComponent implements OnInit {
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'TimeTable',
-    classes: "table-hover table-dark clickable-table",
+    classes: 'table-hover table-dark clickable-table',
     showColumns: true,
     showExport: true,
     exportFileName: 'Systems_TIME_Report',
-    headerStyle: "bg-danger",
+    headerStyle: 'bg-danger',
     pagination: true,
     search: true,
     sortName: 'Name',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.timeUrl
+    url: this.apiService.timeUrl,
   });
 
   // TIME Table Columns
-  columnDefs: any[] = [{
-    field: 'System Name',
-    title: 'System Name',
-    sortable: true
-  }, {
-    field: 'FY',
-    title: 'FY',
-    sortable: true
-  }, {
-    field: 'TIME Designation',
-    title: 'TIME Designation',
-    sortable: true
-  }, {
-    field: 'Business Score',
-    title: 'Business Score',
-    sortable: true
-  }, {
-    field: 'Technical Score',
-    title: 'Technical Score',
-    sortable: true
-  }, {
-    field: 'O&M Cost',
-    title: 'O&M Cost',
-    sortable: true
-  }, {
-    field: 'DM&E Cost',
-    title: 'DM&E Cost',
-    sortable: true
-  }, {
-    field: 'Software/Hardware License Costs',
-    title: 'License Costs',
-    sortable: true
-  }, {
-    field: 'Questionnaire Last Updated',
-    title: 'Questionnaire Last Updated',
-    sortable: true,
-    formatter: this.sharedService.dateFormatter
-  }, {
-    field: 'POC Last Updated',
-    title: 'POC of Last Updated',
-    sortable: true,
-    formatter: this.sharedService.emailFormatter
-  }, {
-    field: 'File Link',
-    title: 'File Link',
-    sortable: true,
-    formatter: this.sharedService.linksFormatter
-  }];
+  columnDefs: any[] = [
+    {
+      field: 'System Name',
+      title: 'System Name',
+      sortable: true,
+    },
+    {
+      field: 'FY',
+      title: 'FY',
+      sortable: true,
+    },
+    {
+      field: 'TIME Designation',
+      title: 'TIME Designation',
+      sortable: true,
+    },
+    {
+      field: 'Business Score',
+      title: 'Business Score',
+      sortable: true,
+    },
+    {
+      field: 'Technical Score',
+      title: 'Technical Score',
+      sortable: true,
+    },
+    {
+      field: 'O&M Cost',
+      title: 'O&M Cost',
+      sortable: true,
+    },
+    {
+      field: 'DM&E Cost',
+      title: 'DM&E Cost',
+      sortable: true,
+    },
+    {
+      field: 'Software/Hardware License Costs',
+      title: 'License Costs',
+      sortable: true,
+    },
+    {
+      field: 'Questionnaire Last Updated',
+      title: 'Questionnaire Last Updated',
+      sortable: true,
+      formatter: this.sharedService.dateFormatter,
+    },
+    {
+      field: 'POC Last Updated',
+      title: 'POC of Last Updated',
+      sortable: true,
+      formatter: this.sharedService.emailFormatter,
+    },
+    {
+      field: 'File Link',
+      title: 'File Link',
+      sortable: true,
+      formatter: this.sharedService.linksFormatter,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
-    })
+      $('[data-toggle="popover"]').popover();
+    });
 
-    $('#timeTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.columnDefs,
-      data: [],
-    }));
+    $('#timeTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.columnDefs,
+        data: [],
+      })
+    );
 
     // Method to handle click events on the Systems table
     $(document).ready(
-      $('#timeTable').on('dbl-click-row.bs.table', function (e, row) {
-        // Grab data for system by name
-        this.apiService.getOneSys(row['System Id']).subscribe((data: any[]) => {
-          this.tableService.systemsTableClick(data[0]) });
+      $('#timeTable').on(
+        'dbl-click-row.bs.table',
+        function (e, row) {
+          // Grab data for system by name
+          this.apiService
+            .getOneSys(row['System Id'])
+            .subscribe((data: any[]) => {
+              this.tableService.systemsTableClick(data[0]);
+            });
 
           // Change URL to include ID
           this.sharedService.addIDtoURL(row, 'Id');
-      }.bind(this)
-      ));
+        }.bind(this)
+      )
+    );
 
     // Visualization data
     this.apiService.getTIME().subscribe((data: any[]) => {
       var yearTimeCount = {};
 
       // Count number of each TIME value for each FY
-      data.forEach(row => {
+      data.forEach((row) => {
         let year = row['FY'];
         let timeVal = row['TIME Designation'];
 
-        if (!(year in yearTimeCount)) yearTimeCount[year] = {};  // If year does not exist, add it
-        if (!(timeVal in yearTimeCount[year])) yearTimeCount[year][timeVal] = 1;  // If time value for year does not exist, initialize to 1
-        else yearTimeCount[year][timeVal]++;  // Else, increment time value for year by 1
+        if (!(year in yearTimeCount)) yearTimeCount[year] = {}; // If year does not exist, add it
+        if (!(timeVal in yearTimeCount[year])) yearTimeCount[year][timeVal] = 1;
+        // If time value for year does not exist, initialize to 1
+        else yearTimeCount[year][timeVal]++; // Else, increment time value for year by 1
       });
-      
+
       // Layout counts to form to be ingested to visual
       for (const [fy, timeCount] of Object.entries(yearTimeCount).sort()) {
         let dataPoint = {};
@@ -170,7 +193,7 @@ export class TimeComponent implements OnInit {
           obj['value'] = count;
 
           dataPoint['series'].push(obj);
-        };
+        }
         this.vizData.push(dataPoint);
       }
 
@@ -178,26 +201,27 @@ export class TimeComponent implements OnInit {
       this.vizData = [...this.vizData];
 
       // Set color scheme for chart
-      this.colorScheme = this.colorSets.find(s => s.name === 'vivid');
+      this.colorScheme = this.colorSets.find((s) => s.name === 'vivid');
 
       // console.log(this.vizData);  // Debug
     });
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailSysID = params['sysID'];
       if (detailSysID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailSysID}`
+        );
         this.apiService.getOneSys(detailSysID).subscribe((data: any[]) => {
           this.tableService.systemsTableClick(data[0]);
           // this.getInterfaceData(row.ID);
         });
-      };
+      }
     });
-    
   }
 
   onSelect(event) {
     console.log(event);
   }
-
 }

--- a/src/app/views/systems/websites/websites.component.ts
+++ b/src/app/views/systems/websites/websites.component.ts
@@ -173,7 +173,7 @@ export class WebsitesComponent implements OnInit {
     this.route.params.subscribe((params) => {
       var detailwebsiteID = params['websiteID'];
       this.titleService.setTitle(
-        `${this.titleService.getTitle()} | ${detailwebsiteID}`
+        `${this.titleService.getTitle()} - ${detailwebsiteID}`
       );
       if (detailwebsiteID) {
         this.apiService

--- a/src/app/views/systems/websites/websites.component.ts
+++ b/src/app/views/systems/websites/websites.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 // Declare jQuery symbol
 declare var $: any;
@@ -23,7 +24,8 @@ export class WebsitesComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     public sharedService: SharedService,
-    private tableService: TableService
+    private tableService: TableService,
+    private titleService: Title
   ) {}
 
   // Websites Table Options
@@ -170,6 +172,7 @@ export class WebsitesComponent implements OnInit {
     // Method to open details modal when referenced directly via URL
     this.route.params.subscribe((params) => {
       var detailwebsiteID = params['websiteID'];
+      this.titleService.setTitle(detailwebsiteID);
       if (detailwebsiteID) {
         this.apiService
           .getOneWebsite(detailwebsiteID)

--- a/src/app/views/systems/websites/websites.component.ts
+++ b/src/app/views/systems/websites/websites.component.ts
@@ -171,11 +171,12 @@ export class WebsitesComponent implements OnInit {
 
     // Method to open details modal when referenced directly via URL
     this.route.params.subscribe((params) => {
-      var detailwebsiteID = params['websiteID'];
-      this.titleService.setTitle(
-        `${this.titleService.getTitle()} - ${detailwebsiteID}`
-      );
+      let detailwebsiteID = params['websiteID'];
+
       if (detailwebsiteID) {
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailwebsiteID}`
+        );
         this.apiService
           .getOneWebsite(detailwebsiteID)
           .subscribe((data: any[]) => {

--- a/src/app/views/systems/websites/websites.component.ts
+++ b/src/app/views/systems/websites/websites.component.ts
@@ -172,7 +172,9 @@ export class WebsitesComponent implements OnInit {
     // Method to open details modal when referenced directly via URL
     this.route.params.subscribe((params) => {
       var detailwebsiteID = params['websiteID'];
-      this.titleService.setTitle(detailwebsiteID);
+      this.titleService.setTitle(
+        `${this.titleService.getTitle()} | ${detailwebsiteID}`
+      );
       if (detailwebsiteID) {
         this.apiService
           .getOneWebsite(detailwebsiteID)

--- a/src/app/views/technologies/it-standards/it-standards.component.ts
+++ b/src/app/views/technologies/it-standards/it-standards.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '@services/apis/api.service';
 import { ModalsService } from '@services/modals/modals.service';
 import { SharedService } from '@services/shared/shared.service';
 import { TableService } from '@services/tables/table.service';
+import { Title } from '@angular/platform-browser';
 
 import { ITStandards } from '@api/models/it-standards.model';
 
@@ -15,10 +16,9 @@ declare var $: any;
 @Component({
   selector: 'it-standards',
   templateUrl: './it-standards.component.html',
-  styleUrls: ['./it-standards.component.css']
+  styleUrls: ['./it-standards.component.css'],
 })
 export class ItStandardsComponent implements OnInit {
-
   row: Object = <any>{};
   filteredTable: boolean = false;
   filterTitle: string = '';
@@ -30,116 +30,139 @@ export class ItStandardsComponent implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     public sharedService: SharedService,
-    private tableService: TableService) {
-    this.modalService.currentITStand.subscribe(row => this.row = row);
+    private tableService: TableService,
+    private titleService: Title
+  ) {
+    this.modalService.currentITStand.subscribe((row) => (this.row = row));
   }
 
   // IT Standard Table Options
   tableOptions: {} = this.tableService.createTableOptions({
     advancedSearch: true,
     idTable: 'ITStandardTable',
-    classes: "table-hover table-dark clickable-table fixed-table",
+    classes: 'table-hover table-dark clickable-table fixed-table',
     showColumns: true,
     showExport: true,
     exportFileName: 'GSA_IT_Standards',
-    headerStyle: "bg-teal",
+    headerStyle: 'bg-teal',
     pagination: true,
     search: true,
     sortName: 'Name',
     sortOrder: 'asc',
     showToggle: true,
-    url: this.apiService.techUrl
+    url: this.apiService.techUrl,
   });
 
   // IT Standard Table Columns
-  columnDefs: any[] = [{
-    field: 'ID',
-    title: 'ID',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Name',
-    title: 'Standard Name',
-    sortable: true
-  }, {
-    field: 'Description',
-    title: 'Description',
-    sortable: true,
-    class: 'text-truncate'
-  }, {
-    field: 'Category',
-    title: 'Category',
-    sortable: true
-  }, {
-    field: 'Status',
-    title: 'Status',
-    sortable: true
-  }, {
-    field: 'StandardType',
-    title: 'Standard Type',
-    sortable: true
-  }, {
-    field: 'DeploymentType',
-    title: 'Deployment Type',
-    sortable: true
-  }, {
-    field: 'ComplianceStatus',
-    title: '508 Compliance',
-    sortable: true
-  }, {
-    field: 'POC',
-    title: 'POC',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'POCorg',
-    title: 'POC Org',
-    sortable: true,
-    visible: false
-  }, {
-    field: 'Comments',
-    title: 'Comments',
-    sortable: true
-  }, {
-    field: 'ApprovalExpirationDate',
-    title: 'Approval Expiration Date',
-    sortable: true,
-    visible: false
-  }];
+  columnDefs: any[] = [
+    {
+      field: 'ID',
+      title: 'ID',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Name',
+      title: 'Standard Name',
+      sortable: true,
+    },
+    {
+      field: 'Description',
+      title: 'Description',
+      sortable: true,
+      class: 'text-truncate',
+    },
+    {
+      field: 'Category',
+      title: 'Category',
+      sortable: true,
+    },
+    {
+      field: 'Status',
+      title: 'Status',
+      sortable: true,
+    },
+    {
+      field: 'StandardType',
+      title: 'Standard Type',
+      sortable: true,
+    },
+    {
+      field: 'DeploymentType',
+      title: 'Deployment Type',
+      sortable: true,
+    },
+    {
+      field: 'ComplianceStatus',
+      title: '508 Compliance',
+      sortable: true,
+    },
+    {
+      field: 'POC',
+      title: 'POC',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'POCorg',
+      title: 'POC Org',
+      sortable: true,
+      visible: false,
+    },
+    {
+      field: 'Comments',
+      title: 'Comments',
+      sortable: true,
+    },
+    {
+      field: 'ApprovalExpirationDate',
+      title: 'Approval Expiration Date',
+      sortable: true,
+      visible: false,
+    },
+  ];
 
   ngOnInit(): void {
     // Enable popovers
     $(function () {
-      $('[data-toggle="popover"]').popover()
+      $('[data-toggle="popover"]').popover();
     });
 
     // Set JWT when logged into GEAR Manager when returning from secureAuth
     this.sharedService.setJWTonLogIn();
 
-    $('#itStandardsTable').bootstrapTable($.extend(this.tableOptions, {
-      columns: this.columnDefs,
-      data: [],
-    }));
+    $('#itStandardsTable').bootstrapTable(
+      $.extend(this.tableOptions, {
+        columns: this.columnDefs,
+        data: [],
+      })
+    );
 
     // Method to handle click events on the Investments table
     $(document).ready(
-      $('#itStandardsTable').on('click-row.bs.table', function (e, row) {
-        this.tableService.itStandTableClick(row);
-      }.bind(this))
+      $('#itStandardsTable').on(
+        'click-row.bs.table',
+        function (e, row) {
+          this.tableService.itStandTableClick(row);
+        }.bind(this)
+      )
     );
 
     // Method to open details modal when referenced directly via URL
-    this.route.params.subscribe(params => {
+    this.route.params.subscribe((params) => {
       var detailStandID = params['standardID'];
       if (detailStandID) {
-        this.apiService.getOneITStandard(detailStandID).subscribe((data: any[]) => {
-          this.tableService.itStandTableClick(data[0]);
-        });
-      };
+        this.titleService.setTitle(
+          `${this.titleService.getTitle()} - ${detailStandID}`
+        );
+        this.apiService
+          .getOneITStandard(detailStandID)
+          .subscribe((data: any[]) => {
+            this.tableService.itStandTableClick(data[0]);
+          });
+      }
     });
-
   }
-
 
   // Create new IT Standard when in GEAR Manager mode
   createITStand() {
@@ -155,7 +178,7 @@ export class ItStandardsComponent implements OnInit {
 
   // Update table from filter buttons
   changeFilter(field: string, term: string) {
-    this.filteredTable = true;  // Filters are on, expose main table button
+    this.filteredTable = true; // Filters are on, expose main table button
     var filter = {};
     filter[field] = term;
 
@@ -163,25 +186,26 @@ export class ItStandardsComponent implements OnInit {
     $('#itStandardsTable').bootstrapTable('filterBy', filter);
     $('#itStandardsTable').bootstrapTable('refreshOptions', {
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_' + term + '_IT_Standards')
-      }
+        fileName: this.sharedService.fileNameFmt(
+          'GSA_' + term + '_IT_Standards'
+        ),
+      },
     });
 
     this.filterTitle = `${term} `;
   }
 
   backToMainIT() {
-    this.filteredTable = false;  // Hide main button
+    this.filteredTable = false; // Hide main button
 
     // Remove filters and back to default
     $('#itStandardsTable').bootstrapTable('filterBy', {});
     $('#itStandardsTable').bootstrapTable('refreshOptions', {
       exportOptions: {
-        fileName: this.sharedService.fileNameFmt('GSA_IT_Standards')
-      }
+        fileName: this.sharedService.fileNameFmt('GSA_IT_Standards'),
+      },
     });
 
     this.filterTitle = '';
   }
-
 }


### PR DESCRIPTION
Includes the following (in commit order):

- 1 Added tab order for key elements of Websites modal including the chart, links to Service Categories
- 2 Ensured "previous" button in modal was navigable via keyboard
- 3 Added full text and data description of pie/ coxcomb chart for screen readers
- 4 Updated Development Environment banner in header to have sufficient WCAG AA contrast
- 5 Added page title for Websites route to include app name + page name
- 6 to 10 Made updates across other pages containing modals
- 11 Corrected "id" attributes on Service Category page to not conflict with Capabilities
- 12 Added label to global search - placeholder was present but best practice is to include a label with the `sr-only` class
- 13 Updated color contrast on home page cards
- 14 Re-fixed 3 from above 
- 15 Changed color of close icon on Service Category modal
- 16 Websites modal logic for setTitle needed to be pushed into conditional
- 17 Changed color of close icon on remaining modal pages